### PR TITLE
Reset constraints ids between test groups

### DIFF
--- a/tests/snapshots/all__lp_attributes2__0.txt
+++ b/tests/snapshots/all__lp_attributes2__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   n
 Subject To
- 283: 1.0 <= n
+ 6: 1.0 <= n
 Bounds
  n free
 Generals
@@ -24,7 +24,7 @@ GUROBI
 Minimize
   n
 Subject To
- 283: n >= 1
+ 6: n >= 1
 Bounds
  n free
 Generals

--- a/tests/snapshots/all__lp_attributes4__0.txt
+++ b/tests/snapshots/all__lp_attributes4__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Maximize
   x + n + b
 Subject To
- 291: n <= 1.0
+ 14: n <= 1.0
 Bounds
  x <= 0.0
  n free
@@ -31,7 +31,7 @@ GUROBI
 Maximize
   x + n + b
 Subject To
- 291: n <= 1
+ 14: n <= 1
 Bounds
  -infinity <= x <= 0
  n free

--- a/tests/snapshots/all__lp_matrix0__0.txt
+++ b/tests/snapshots/all__lp_matrix0__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 160: 1.0 <= x
+ 7: 1.0 <= x
 Bounds
  x free
 End
@@ -22,8 +22,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 160[0]: x[0] >= 1
- 160[1]: x[1] >= 1
+ 7[0]: x[0] >= 1
+ 7[1]: x[1] >= 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix10__0.txt
+++ b/tests/snapshots/all__lp_matrix10__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 244: [[0.0 1.0]
+ 91: [[0.0 1.0]
  [2.0 3.0]] @ x + y == 1.0
 Bounds
  x free
@@ -26,8 +26,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 244[0]: x[1] + y[0] = 1
- 244[1]: 2 x[0] + 3 x[1] + y[1] = 1
+ 91[0]: x[1] + y[0] = 1
+ 91[1]: 2 x[0] + 3 x[1] + y[1] = 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix11__0.txt
+++ b/tests/snapshots/all__lp_matrix11__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 254: [[0.0 1.0]
+ 101: [[0.0 1.0]
  [2.0 3.0]] @ x + y + Promote(1.0, (2,)) == 0.0
 Bounds
  x free
@@ -26,8 +26,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 254[0]: x[1] + y[0] = -1
- 254[1]: 2 x[0] + 3 x[1] + y[1] = -1
+ 101[0]: x[1] + y[0] = -1
+ 101[1]: 2 x[0] + 3 x[1] + y[1] = -1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix1__0.txt
+++ b/tests/snapshots/all__lp_matrix1__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 166: 1.0 <= x
- 171: x <= 2.0
+ 13: 1.0 <= x
+ 18: x <= 2.0
 Bounds
  x free
 End
@@ -25,10 +25,10 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 166[0]: x[0] >= 1
- 166[1]: x[1] >= 1
- 171[0]: x[0] <= 2
- 171[1]: x[1] <= 2
+ 13[0]: x[0] >= 1
+ 13[1]: x[1] >= 1
+ 18[0]: x[0] <= 2
+ 18[1]: x[1] <= 2
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix2__0.txt
+++ b/tests/snapshots/all__lp_matrix2__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 177: x == 1.0
+ 24: x == 1.0
 Bounds
  x free
 End
@@ -22,8 +22,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 177[0]: x[0] = 1
- 177[1]: x[1] = 1
+ 24[0]: x[0] = 1
+ 24[1]: x[1] = 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix3__0.txt
+++ b/tests/snapshots/all__lp_matrix3__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 183: x == 1.0
- 188: y == 1.0
+ 30: x == 1.0
+ 35: y == 1.0
 Bounds
  x free
  y free
@@ -28,10 +28,10 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 183[0]: x[0] = 1
- 183[1]: x[1] = 1
- 188[0]: y[0] = 1
- 188[1]: y[1] = 1
+ 30[0]: x[0] = 1
+ 30[1]: x[1] = 1
+ 35[0]: y[0] = 1
+ 35[1]: y[1] = 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix4__0.txt
+++ b/tests/snapshots/all__lp_matrix4__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 195: 1.0 <= x + y
+ 42: 1.0 <= x + y
 Bounds
  x free
  y free
@@ -25,8 +25,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 195[0]: x[0] + y[0] >= 1
- 195[1]: x[1] + y[1] >= 1
+ 42[0]: x[0] + y[0] >= 1
+ 42[1]: x[1] + y[1] >= 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix5__0.txt
+++ b/tests/snapshots/all__lp_matrix5__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 204: 0.0 <= x + y + Promote(1.0, (2,))
+ 51: 0.0 <= x + y + Promote(1.0, (2,))
 Bounds
  x free
  y free
@@ -25,8 +25,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 204[0]: x[0] + y[0] >= -1
- 204[1]: x[1] + y[1] >= -1
+ 51[0]: x[0] + y[0] >= -1
+ 51[1]: x[1] + y[1] >= -1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix6__0.txt
+++ b/tests/snapshots/all__lp_matrix6__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 211: [[0.00 1.00]
+ 58: [[0.00 1.00]
  [2.00 3.00]] @ x == 1.0
 Bounds
  x free
@@ -23,8 +23,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 211[0]: x[1] = 1
- 211[1]: 2 x[0] + 3 x[1] = 1
+ 58[0]: x[1] = 1
+ 58[1]: 2 x[0] + 3 x[1] = 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix7__0.txt
+++ b/tests/snapshots/all__lp_matrix7__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 219: [[0.00 1.00]
+ 66: [[0.00 1.00]
  [2.00 3.00]] @ x + y == 1.0
 Bounds
  x free
@@ -26,8 +26,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 219[0]: x[1] + y[0] = 1
- 219[1]: 2 x[0] + 3 x[1] + y[1] = 1
+ 66[0]: x[1] + y[0] = 1
+ 66[1]: 2 x[0] + 3 x[1] + y[1] = 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix8__0.txt
+++ b/tests/snapshots/all__lp_matrix8__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 229: [[0.00 1.00]
+ 76: [[0.00 1.00]
  [2.00 3.00]] @ x + y + Promote(1.0, (2,)) == 0.0
 Bounds
  x free
@@ -26,8 +26,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 229[0]: x[1] + y[0] = -1
- 229[1]: 2 x[0] + 3 x[1] + y[1] = -1
+ 76[0]: x[1] + y[0] = -1
+ 76[1]: 2 x[0] + 3 x[1] + y[1] = -1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix9__0.txt
+++ b/tests/snapshots/all__lp_matrix9__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 236: [[0.0 1.0]
+ 83: [[0.0 1.0]
  [2.0 3.0]] @ x == 1.0
 Bounds
  x free
@@ -23,8 +23,8 @@ GUROBI
 Minimize
   x[0] + x[1]
 Subject To
- 236[0]: x[1] = 1
- 236[1]: 2 x[0] + 3 x[1] = 1
+ 83[0]: x[1] = 1
+ 83[1]: 2 x[0] + 3 x[1] = 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix_quadratic2__0.txt
+++ b/tests/snapshots/all__lp_matrix_quadratic2__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Maximize
   Sum(x, None, False)
 Subject To
- 266: quad_over_lin(x, 1.0) <= 1.0
+ 11: quad_over_lin(x, 1.0) <= 1.0
 Bounds
  x free
 End
@@ -30,7 +30,7 @@ GUROBI
 Maximize
   x[0] + x[1]
 Subject To
- 266: [ x[0] ^2 + x[1] ^2 ] <= 1
+ 11: [ x[0] ^2 + x[1] ^2 ] <= 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_matrix_quadratic3__0.txt
+++ b/tests/snapshots/all__lp_matrix_quadratic3__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   quad_over_lin(x, 1.0)
 Subject To
- 272: quad_over_lin(x, 1.0) <= 1.0
+ 17: quad_over_lin(x, 1.0) <= 1.0
 Bounds
  x free
 End
@@ -39,7 +39,7 @@ GUROBI
 Minimize
  [ 2 x[0] ^2 + 2 x[1] ^2 ] / 2 
 Subject To
- 272: [ x[0] ^2 + x[1] ^2 ] <= 1
+ 17: [ x[0] ^2 + x[1] ^2 ] <= 1
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_scalar_linear0__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear0__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   x
 Subject To
- 36: 1.0 <= x
+ 5: 1.0 <= x
 Bounds
  x free
 End
@@ -20,7 +20,7 @@ GUROBI
 Minimize
   x
 Subject To
- 36: x >= 1
+ 5: x >= 1
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_scalar_linear10__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear10__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   x
 Subject To
- 103: x + y == 1.0
+ 72: x + y == 1.0
 Bounds
  x free
  y free
@@ -22,7 +22,7 @@ GUROBI
 Minimize
   x
 Subject To
- 103: x + y = 1
+ 72: x + y = 1
 Bounds
  x free
  y free

--- a/tests/snapshots/all__lp_scalar_linear11__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear11__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   x
 Subject To
- 108: 1.0 <= 2.0 @ x
+ 77: 1.0 <= 2.0 @ x
 Bounds
  x free
 End
@@ -20,7 +20,7 @@ GUROBI
 Minimize
   x
 Subject To
- 108: 2 x >= 1
+ 77: 2 x >= 1
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_scalar_linear12__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear12__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   x
 Subject To
- 114: 1.0 <= 2.0 @ x + y
+ 83: 1.0 <= 2.0 @ x + y
 Bounds
  x free
  y free
@@ -22,7 +22,7 @@ GUROBI
 Minimize
   x
 Subject To
- 114: 2 x + y >= 1
+ 83: 2 x + y >= 1
 Bounds
  x free
  y free

--- a/tests/snapshots/all__lp_scalar_linear1__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear1__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Maximize
   x
 Subject To
- 40: x <= 1.0
+ 9: x <= 1.0
 Bounds
  x free
 End
@@ -20,7 +20,7 @@ GUROBI
 Maximize
   x
 Subject To
- 40: x <= 1
+ 9: x <= 1
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_scalar_linear2__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear2__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   x
 Subject To
- 44: x == 1.0
+ 13: x == 1.0
 Bounds
  x free
 End
@@ -20,7 +20,7 @@ GUROBI
 Minimize
   x
 Subject To
- 44: x = 1
+ 13: x = 1
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_scalar_linear3__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear3__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   x
 Subject To
- 48: 1.0 <= x
- 52: x <= 2.0
+ 17: 1.0 <= x
+ 21: x <= 2.0
 Bounds
  x free
 End
@@ -22,8 +22,8 @@ GUROBI
 Minimize
   x
 Subject To
- 48: x >= 1
- 52: x <= 2
+ 17: x >= 1
+ 21: x <= 2
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_scalar_linear4__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear4__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   x
 Subject To
- 56: 1.0 <= x
- 60: x <= 1.0
+ 25: 1.0 <= x
+ 29: x <= 1.0
 Bounds
  x free
 End
@@ -22,8 +22,8 @@ GUROBI
 Minimize
   x
 Subject To
- 56: x >= 1
- 60: x <= 1
+ 25: x >= 1
+ 29: x <= 1
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_scalar_linear5__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear5__0.txt
@@ -2,9 +2,9 @@ CVXPY
 Minimize
   x
 Subject To
- 64: 0.0 <= x
- 68: x <= 2.0
- 72: x == 1.0
+ 33: 0.0 <= x
+ 37: x <= 2.0
+ 41: x == 1.0
 Bounds
  x free
 End
@@ -24,9 +24,9 @@ GUROBI
 Minimize
   x
 Subject To
- 64: x >= 0
- 68: x <= 2
- 72: x = 1
+ 33: x >= 0
+ 37: x <= 2
+ 41: x = 1
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_scalar_linear6__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear6__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   x
 Subject To
- 76: 1.0 <= x
- 80: 1.0 <= y
+ 45: 1.0 <= x
+ 49: 1.0 <= y
 Bounds
  x free
  y free
@@ -24,8 +24,8 @@ GUROBI
 Minimize
   x
 Subject To
- 76: x >= 1
- 80: y >= 1
+ 45: x >= 1
+ 49: y >= 1
 Bounds
  x free
  y free

--- a/tests/snapshots/all__lp_scalar_linear7__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear7__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   x
 Subject To
- 84: x == 1.0
- 88: y == 1.0
+ 53: x == 1.0
+ 57: y == 1.0
 Bounds
  x free
  y free
@@ -24,8 +24,8 @@ GUROBI
 Minimize
   x
 Subject To
- 84: x = 1
- 88: y = 1
+ 53: x = 1
+ 57: y = 1
 Bounds
  x free
  y free

--- a/tests/snapshots/all__lp_scalar_linear8__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear8__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   x
 Subject To
- 93: 1.0 <= x + y
+ 62: 1.0 <= x + y
 Bounds
  x free
  y free
@@ -22,7 +22,7 @@ GUROBI
 Minimize
   x
 Subject To
- 93: x + y >= 1
+ 62: x + y >= 1
 Bounds
  x free
  y free

--- a/tests/snapshots/all__lp_scalar_linear9__0.txt
+++ b/tests/snapshots/all__lp_scalar_linear9__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   x
 Subject To
- 98: x + y <= 1.0
+ 67: x + y <= 1.0
 Bounds
  x free
  y free
@@ -22,7 +22,7 @@ GUROBI
 Minimize
   x
 Subject To
- 98: x + y <= 1
+ 67: x + y <= 1
 Bounds
  x free
  y free

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import wraps
-from itertools import chain
 from typing import Callable
 from typing import Iterator
 
@@ -37,15 +36,18 @@ def group_cases(
 
 
 def all_problems() -> Iterator[ProblemTestCase]:
-    yield from chain(
-        simple_expressions(),
-        scalar_linear_constraints(),
-        quadratic_expressions(),
-        matrix_constraints(),
-        matrix_quadratic_expressions(),
-        attributes(),
-        invalid_expressions(),
-    )
+    for problem_gen in (
+        simple_expressions,
+        scalar_linear_constraints,
+        quadratic_expressions,
+        matrix_constraints,
+        matrix_quadratic_expressions,
+        attributes,
+        invalid_expressions,
+    ):
+        # Make sure order of groups does not matter
+        reset_id_counter()
+        yield from problem_gen()
 
 
 def all_valid_problems() -> Iterator[ProblemTestCase]:
@@ -189,3 +191,11 @@ def invalid_expressions() -> Iterator[cp.Problem]:
     # TODO: maybe using setPWLObj?
     yield cp.Problem(cp.Minimize(cp.abs(x)))
     yield cp.Problem(cp.Maximize(cp.sqrt(x)))
+
+
+def reset_id_counter() -> tuple:
+    """Reset the counter used to assign constraint ids."""
+    from cvxpy.lin_ops.lin_utils import ID_COUNTER
+
+    ID_COUNTER.count = 1
+    return ()


### PR DESCRIPTION
Without this, adding a test case will increase the constraint ids for all following test problems, even those in other groups.