### PR TITLE
Add support for expression indexing

### DIFF
--- a/tests/snapshots/all__lp_indexing0__0.txt
+++ b/tests/snapshots/all__lp_indexing0__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Minimize
+  x[0]
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + 0 x[1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing10__0.txt
+++ b/tests/snapshots/all__lp_indexing10__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(x + [1. 2.][ True False], None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + 0 x[1] + Constant
+Subject To
+Bounds
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_indexing11__0.txt
+++ b/tests/snapshots/all__lp_indexing11__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(m[ True False], None, False)
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C2
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + m[0,1] + 0 m[1,0] + 0 m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing12__0.txt
+++ b/tests/snapshots/all__lp_indexing12__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(m(array([ True, False]), slice(None, None, None)), None, False)
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C2
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + m[0,1] + 0 m[1,0] + 0 m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing13__0.txt
+++ b/tests/snapshots/all__lp_indexing13__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Minimize
+  Sum(x[0:2], None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + x[1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing14__0.txt
+++ b/tests/snapshots/all__lp_indexing14__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(x + [1. 2.][0:2], None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + x[1] + 3 Constant
+Subject To
+Bounds
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_indexing15__0.txt
+++ b/tests/snapshots/all__lp_indexing15__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(m[0:2, 0:2], None, False)
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + m[0,1] + m[1,0] + m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing1__0.txt
+++ b/tests/snapshots/all__lp_indexing1__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  x + [1. 2.][0]
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + 0 x[1] + Constant
+Subject To
+Bounds
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_indexing2__0.txt
+++ b/tests/snapshots/all__lp_indexing2__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  m[0, 0]
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + 0 m[0,1] + 0 m[1,0] + 0 m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing3__0.txt
+++ b/tests/snapshots/all__lp_indexing3__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(m[0, 0:2], None, False)
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C2
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + m[0,1] + 0 m[1,0] + 0 m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing4__0.txt
+++ b/tests/snapshots/all__lp_indexing4__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(m[0, 0:2], None, False)
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C2
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + m[0,1] + 0 m[1,0] + 0 m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing5__0.txt
+++ b/tests/snapshots/all__lp_indexing5__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Minimize
+  Sum(x[0], None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + 0 x[1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing6__0.txt
+++ b/tests/snapshots/all__lp_indexing6__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(x + [1. 2.][0], None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + 0 x[1] + Constant
+Subject To
+Bounds
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_indexing7__0.txt
+++ b/tests/snapshots/all__lp_indexing7__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(m[0], None, False)
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C2
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + m[0,1] + 0 m[1,0] + 0 m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing8__0.txt
+++ b/tests/snapshots/all__lp_indexing8__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(m(array([0]), slice(None, None, None)), None, False)
+Subject To
+Bounds
+ 0.0 <= m
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C2
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  m[0,0] + m[0,1] + 0 m[1,0] + 0 m[1,1]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_indexing9__0.txt
+++ b/tests/snapshots/all__lp_indexing9__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Minimize
+  Sum(x[ True False], None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + 0 x[1]
+Subject To
+Bounds
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -42,6 +42,7 @@ def all_problems() -> Iterator[ProblemTestCase]:
         quadratic_expressions,
         matrix_constraints,
         matrix_quadratic_expressions,
+        indexing,
         attributes,
         invalid_expressions,
     ):
@@ -165,6 +166,37 @@ def matrix_quadratic_expressions() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum_squares(S @ x)))
 
 
+@group_cases("indexing")
+def indexing() -> Iterator[cp.Problem]:
+    x = cp.Variable(2, name="x", nonneg=True)
+    m = cp.Variable((2, 2), name="m", nonneg=True)
+    y = x + np.array([1, 2])
+
+    idx = 0
+    yield cp.Problem(cp.Minimize(x[idx]))
+    yield cp.Problem(cp.Minimize(y[idx]))
+    yield cp.Problem(cp.Minimize(m[idx, idx]))
+
+    yield cp.Problem(cp.Minimize(cp.sum(m[idx])))
+    yield cp.Problem(cp.Minimize(cp.sum(m[idx, :])))
+
+    idx = np.array([0])
+    yield cp.Problem(cp.Minimize(cp.sum(x[idx])))
+    yield cp.Problem(cp.Minimize(cp.sum(y[idx])))
+    yield cp.Problem(cp.Minimize(cp.sum(m[idx])))
+    yield cp.Problem(cp.Minimize(cp.sum(m[idx, :])))
+
+    idx = np.array([True, False])
+    yield cp.Problem(cp.Minimize(cp.sum(x[idx])))
+    yield cp.Problem(cp.Minimize(cp.sum(y[idx])))
+    yield cp.Problem(cp.Minimize(cp.sum(m[idx])))
+    yield cp.Problem(cp.Minimize(cp.sum(m[idx, :])))
+
+    yield cp.Problem(cp.Minimize(cp.sum(x[:])))
+    yield cp.Problem(cp.Minimize(cp.sum(y[:])))
+    yield cp.Problem(cp.Minimize(cp.sum(m[:, :])))
+
+
 @group_cases("attributes")
 def attributes() -> Iterator[cp.Problem]:
     x = cp.Variable(nonpos=True, name="x")
@@ -193,9 +225,8 @@ def invalid_expressions() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Maximize(cp.sqrt(x)))
 
 
-def reset_id_counter() -> tuple:
+def reset_id_counter() -> None:
     """Reset the counter used to assign constraint ids."""
     from cvxpy.lin_ops.lin_utils import ID_COUNTER
 
     ID_COUNTER.count = 1
-    return ()


### PR DESCRIPTION
Expressions such as `x[0]`.

By the way, fixed a bug in matrix variable names and added more information to "unsupported" error messages.