### PR TITLE
Create Gurobi variables during translation

### DIFF
--- a/src/cvxpy_gurobi/__init__.py
+++ b/src/cvxpy_gurobi/__init__.py
@@ -347,13 +347,14 @@ class Translater:
 
     def visit(self, node: Canonical) -> Any:
         visitor = getattr(self, f"visit_{type(node).__name__}", None)
-        if visitor is None:
-            if isinstance(node, cp.Constraint):
-                raise UnsupportedConstraintError(node)
-            if isinstance(node, cp.Expression):
-                raise UnsupportedExpressionError(node)
-            raise UnsupportedError(node)
-        return visitor(node)
+        if visitor is not None:
+            return visitor(node)
+
+        if isinstance(node, cp.Constraint):
+            raise UnsupportedConstraintError(node)
+        if isinstance(node, cp.Expression):
+            raise UnsupportedExpressionError(node)
+        raise UnsupportedError(node)
 
     def visit_AddExpression(self, node: AddExpression) -> Any:
         args = list(map(self.visit, node.args))

--- a/src/cvxpy_gurobi/__init__.py
+++ b/src/cvxpy_gurobi/__init__.py
@@ -293,21 +293,6 @@ def _matrix_to_gurobi_names(
         yield idx, f"{base_name}[{formatted_idx}]"
 
 
-class ObjectiveBuilder:
-    def __init__(self, translater: Translater) -> None:
-        self.translater = translater
-        self.m = translater.model
-
-
-class ConstraintsBuilder:
-    def __init__(self, translater: Translater) -> None:
-        self.translater = translater
-        self.m = translater.model
-
-    def translate(self, node: cp.Expression) -> Any:
-        return self.translater.visit(node)
-
-
 def translate_variable(var: cp.Variable, model: gp.Model) -> AnyVar:
     lb = -gp.GRB.INFINITY
     ub = gp.GRB.INFINITY

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -1,9 +1,10 @@
 import cvxpy as cp
+import gurobipy as gp
 import pytest
 
 import cvxpy_gurobi
 import test_problems
-from cvxpy_gurobi import ExpressionTranslater
+from cvxpy_gurobi import Translater
 
 
 @pytest.mark.xfail(reason="TODO: implement all atoms")
@@ -11,13 +12,13 @@ def test_no_missing_atoms() -> None:
     missing = [
         atom
         for atom in cp.EXP_ATOMS + cp.PSD_ATOMS + cp.SOC_ATOMS + cp.NONPOS_ATOMS
-        if getattr(ExpressionTranslater, f"visit_{atom.__name__}", None) is None  # type: ignore[attr-defined]
+        if getattr(Translater, f"visit_{atom.__name__}", None) is None  # type: ignore[attr-defined]
     ]
     assert missing == []
 
 
 @pytest.mark.parametrize("case", test_problems.invalid_expressions())
 def test_failing_atoms(case) -> None:
-    translater = ExpressionTranslater({})
-    with pytest.raises(cvxpy_gurobi.UnsupportedError):
+    translater = Translater(gp.Model())
+    with pytest.raises(cvxpy_gurobi.UnsupportedExpressionError):
         translater.visit(case.problem.objective.expr)


### PR DESCRIPTION
As opposed to having a specific step before translation. It helps to make variables similar to other nodes. This will be necessary to support more complex expressions #23 as some expressions' translation may require additional variables.

Removing the `map_variables` step revealed that separating the objective and constraint translaters was unnecessary, as now any translation method may add variables/constraints to the model.

One downside is that the translation can no longer be run "model-free" to generate modle-agnostic expressions. This impression was wrong however as any variable used in these expressions was linked to a Gurobi model anyway.