### PR TITLE
Add support for `abs`, `min` and `max` atoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Added
+
+- Handle CVXPY atoms that have an equivalent generalized expression
+  in `gurobipy`. They are translated by adding auxilliary variables
+  constrained to the value of the arguments of the atom to the problem.
+
 # [0.1.0] - 2024-08-01
 
 This is the first release of `cvxpy-gurobi`!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,5 +163,6 @@ omit = [
 ]
 [tool.coverage.report]
 exclude_also = [
-  'if TYPE_CHECKING:',
+  "if TYPE_CHECKING:",
+  "@overload",
 ]

--- a/tests/snapshots/all__lp_genexpr_matrix0__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix0__0.txt
@@ -1,0 +1,46 @@
+CVXPY
+Minimize
+  Sum(abs(X), None, False)
+Subject To
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 + C4 <= 0
+ R1: - C1 + C5 <= 0
+ R2: - C2 + C6 <= 0
+ R3: - C3 + C7 <= 0
+ R4: - C0 - C4 <= 0
+ R5: - C1 - C5 <= 0
+ R6: - C2 - C6 <= 0
+ R7: - C3 - C7 <= 0
+ R8: - C4 <= 0
+ R9: - C5 <= 0
+ R10: - C6 <= 0
+ R11: - C7 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0,0] + 0 X[0,1] + 0 X[1,0] + 0 X[1,1] + abs_1 + abs_2 + abs_3 + abs_4
+Subject To
+Bounds
+General Constraints
+ GC0: abs_1 = ABS ( X[0,0] )
+ GC1: abs_2 = ABS ( X[0,1] )
+ GC2: abs_3 = ABS ( X[1,0] )
+ GC3: abs_4 = ABS ( X[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix10__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix10__0.txt
@@ -1,0 +1,54 @@
+CVXPY
+Minimize
+  max(X + Y, None, False)
+Subject To
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 + C5 <= 0
+ R1: - C0 + C2 + C6 <= 0
+ R2: - C0 + C3 + C7 <= 0
+ R3: - C0 + C4 + C8 <= 0
+ R4: - C1 <= 0
+ R5: - C2 <= 0
+ R6: - C3 <= 0
+ R7: - C4 <= 0
+ R8: - C5 <= 0
+ R9: - C6 <= 0
+ R10: - C7 <= 0
+ R11: - C8 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  max_5
+Subject To
+ R0: - X[0,0] - Y[0,0] + index_1 = 0
+ R1: - X[0,1] - Y[0,1] + index_2 = 0
+ R2: - X[1,0] - Y[1,0] + index_3 = 0
+ R3: - X[1,1] - Y[1,1] + index_4 = 0
+Bounds
+ index_1 free
+ index_2 free
+ index_3 free
+ index_4 free
+ max_5 free
+General Constraints
+ GC0: max_5 = MAX ( index_1 , index_2 , index_3 , index_4 )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix11__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix11__0.txt
@@ -1,0 +1,73 @@
+CVXPY
+Maximize
+  Sum(minimum(X, Y), None, False)
+Subject To
+ 63: X <= 1.0
+ 68: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 - C4 <= 0
+ R1: - C1 - C5 <= 0
+ R2: - C2 - C6 <= 0
+ R3: - C3 - C7 <= 0
+ R4: - C0 - C8 <= 0
+ R5: - C1 - C9 <= 0
+ R6: - C2 - C10 <= 0
+ R7: - C3 - C11 <= 0
+ R8: - C4 <= 0
+ R9: - C5 <= 0
+ R10: - C6 <= 0
+ R11: - C7 <= 0
+ R12: - C8 <= 0
+ R13: - C9 <= 0
+ R14: - C10 <= 0
+ R15: - C11 <= 0
+ R16: C4 <= 1
+ R17: C5 <= 1
+ R18: C6 <= 1
+ R19: C7 <= 1
+ R20: C8 <= 1
+ R21: C9 <= 1
+ R22: C10 <= 1
+ R23: C11 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  minimum_1 + minimum_2 + minimum_3 + minimum_4
+Subject To
+ 63[0,0]: X[0,0] <= 1
+ 63[0,1]: X[0,1] <= 1
+ 63[1,0]: X[1,0] <= 1
+ 63[1,1]: X[1,1] <= 1
+ 68[0,0]: Y[0,0] <= 1
+ 68[0,1]: Y[0,1] <= 1
+ 68[1,0]: Y[1,0] <= 1
+ 68[1,1]: Y[1,1] <= 1
+Bounds
+General Constraints
+ GC0: minimum_1 = MIN ( X[0,0] , Y[0,0] )
+ GC1: minimum_2 = MIN ( X[0,1] , Y[0,1] )
+ GC2: minimum_3 = MIN ( X[1,0] , Y[1,0] )
+ GC3: minimum_4 = MIN ( X[1,1] , Y[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix12__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix12__0.txt
@@ -1,0 +1,85 @@
+CVXPY
+Maximize
+  Sum(minimum(X, Y, 1.0), None, False)
+Subject To
+ 75: X <= 1.0
+ 80: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 - C4 <= 0
+ R1: - C1 - C5 <= 0
+ R2: - C2 - C6 <= 0
+ R3: - C3 - C7 <= 0
+ R4: - C0 - C8 <= 0
+ R5: - C1 - C9 <= 0
+ R6: - C2 - C10 <= 0
+ R7: - C3 - C11 <= 0
+ R8: - C0 <= 1
+ R9: - C1 <= 1
+ R10: - C2 <= 1
+ R11: - C3 <= 1
+ R12: - C4 <= 0
+ R13: - C5 <= 0
+ R14: - C6 <= 0
+ R15: - C7 <= 0
+ R16: - C8 <= 0
+ R17: - C9 <= 0
+ R18: - C10 <= 0
+ R19: - C11 <= 0
+ R20: C4 <= 1
+ R21: C5 <= 1
+ R22: C6 <= 1
+ R23: C7 <= 1
+ R24: C8 <= 1
+ R25: C9 <= 1
+ R26: C10 <= 1
+ R27: C11 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  minimum_2 + minimum_4 + minimum_6 + minimum_8
+Subject To
+ R0: index_1 = 1
+ R1: index_3 = 1
+ R2: index_5 = 1
+ R3: index_7 = 1
+ 75[0,0]: X[0,0] <= 1
+ 75[0,1]: X[0,1] <= 1
+ 75[1,0]: X[1,0] <= 1
+ 75[1,1]: X[1,1] <= 1
+ 80[0,0]: Y[0,0] <= 1
+ 80[0,1]: Y[0,1] <= 1
+ 80[1,0]: Y[1,0] <= 1
+ 80[1,1]: Y[1,1] <= 1
+Bounds
+ index_1 free
+ index_3 free
+ index_5 free
+ index_7 free
+General Constraints
+ GC0: minimum_2 = MIN ( X[0,0] , Y[0,0] , index_1 )
+ GC1: minimum_4 = MIN ( X[0,1] , Y[0,1] , index_3 )
+ GC2: minimum_6 = MIN ( X[1,0] , Y[1,0] , index_5 )
+ GC3: minimum_8 = MIN ( X[1,1] , Y[1,1] , index_7 )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix12__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix12__0.txt
@@ -58,12 +58,9 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  minimum_2 + minimum_4 + minimum_6 + minimum_8
+  0 Constant_1 + minimum_2 + 0 Constant_3 + minimum_4 + 0 Constant_5
+   + minimum_6 + 0 Constant_7 + minimum_8
 Subject To
- R0: index_1 = 1
- R1: index_3 = 1
- R2: index_5 = 1
- R3: index_7 = 1
  75[0,0]: X[0,0] <= 1
  75[0,1]: X[0,1] <= 1
  75[1,0]: X[1,0] <= 1
@@ -73,13 +70,13 @@ Subject To
  80[1,0]: Y[1,0] <= 1
  80[1,1]: Y[1,1] <= 1
 Bounds
- index_1 free
- index_3 free
- index_5 free
- index_7 free
+ Constant_1 = 1
+ Constant_3 = 1
+ Constant_5 = 1
+ Constant_7 = 1
 General Constraints
- GC0: minimum_2 = MIN ( X[0,0] , Y[0,0] , index_1 )
- GC1: minimum_4 = MIN ( X[0,1] , Y[0,1] , index_3 )
- GC2: minimum_6 = MIN ( X[1,0] , Y[1,0] , index_5 )
- GC3: minimum_8 = MIN ( X[1,1] , Y[1,1] , index_7 )
+ GC0: minimum_2 = MIN ( X[0,0] , Y[0,0] , Constant_1 )
+ GC1: minimum_4 = MIN ( X[0,1] , Y[0,1] , Constant_3 )
+ GC2: minimum_6 = MIN ( X[1,0] , Y[1,0] , Constant_5 )
+ GC3: minimum_8 = MIN ( X[1,1] , Y[1,1] , Constant_7 )
 End

--- a/tests/snapshots/all__lp_genexpr_matrix13__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix13__0.txt
@@ -1,0 +1,73 @@
+CVXPY
+Minimize
+  Sum(maximum(X, Y), None, False)
+Subject To
+ 87: 1.0 <= X
+ 92: 1.0 <= Y
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 + C4 <= 0
+ R1: - C1 + C5 <= 0
+ R2: - C2 + C6 <= 0
+ R3: - C3 + C7 <= 0
+ R4: - C0 + C8 <= 0
+ R5: - C1 + C9 <= 0
+ R6: - C2 + C10 <= 0
+ R7: - C3 + C11 <= 0
+ R8: - C4 <= 0
+ R9: - C5 <= 0
+ R10: - C6 <= 0
+ R11: - C7 <= 0
+ R12: - C8 <= 0
+ R13: - C9 <= 0
+ R14: - C10 <= 0
+ R15: - C11 <= 0
+ R16: - C4 <= -1
+ R17: - C5 <= -1
+ R18: - C6 <= -1
+ R19: - C7 <= -1
+ R20: - C8 <= -1
+ R21: - C9 <= -1
+ R22: - C10 <= -1
+ R23: - C11 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  maximum_1 + maximum_2 + maximum_3 + maximum_4
+Subject To
+ 87[0,0]: X[0,0] >= 1
+ 87[0,1]: X[0,1] >= 1
+ 87[1,0]: X[1,0] >= 1
+ 87[1,1]: X[1,1] >= 1
+ 92[0,0]: Y[0,0] >= 1
+ 92[0,1]: Y[0,1] >= 1
+ 92[1,0]: Y[1,0] >= 1
+ 92[1,1]: Y[1,1] >= 1
+Bounds
+General Constraints
+ GC0: maximum_1 = MAX ( X[0,0] , Y[0,0] )
+ GC1: maximum_2 = MAX ( X[0,1] , Y[0,1] )
+ GC2: maximum_3 = MAX ( X[1,0] , Y[1,0] )
+ GC3: maximum_4 = MAX ( X[1,1] , Y[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix14__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix14__0.txt
@@ -1,0 +1,85 @@
+CVXPY
+Minimize
+  Sum(maximum(X, Y, 1.0), None, False)
+Subject To
+ 99: 1.0 <= X
+ 104: 1.0 <= Y
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 + C4 <= 0
+ R1: - C1 + C5 <= 0
+ R2: - C2 + C6 <= 0
+ R3: - C3 + C7 <= 0
+ R4: - C0 + C8 <= 0
+ R5: - C1 + C9 <= 0
+ R6: - C2 + C10 <= 0
+ R7: - C3 + C11 <= 0
+ R8: - C0 <= -1
+ R9: - C1 <= -1
+ R10: - C2 <= -1
+ R11: - C3 <= -1
+ R12: - C4 <= 0
+ R13: - C5 <= 0
+ R14: - C6 <= 0
+ R15: - C7 <= 0
+ R16: - C8 <= 0
+ R17: - C9 <= 0
+ R18: - C10 <= 0
+ R19: - C11 <= 0
+ R20: - C4 <= -1
+ R21: - C5 <= -1
+ R22: - C6 <= -1
+ R23: - C7 <= -1
+ R24: - C8 <= -1
+ R25: - C9 <= -1
+ R26: - C10 <= -1
+ R27: - C11 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  maximum_2 + maximum_4 + maximum_6 + maximum_8
+Subject To
+ R0: index_1 = 1
+ R1: index_3 = 1
+ R2: index_5 = 1
+ R3: index_7 = 1
+ 99[0,0]: X[0,0] >= 1
+ 99[0,1]: X[0,1] >= 1
+ 99[1,0]: X[1,0] >= 1
+ 99[1,1]: X[1,1] >= 1
+ 104[0,0]: Y[0,0] >= 1
+ 104[0,1]: Y[0,1] >= 1
+ 104[1,0]: Y[1,0] >= 1
+ 104[1,1]: Y[1,1] >= 1
+Bounds
+ index_1 free
+ index_3 free
+ index_5 free
+ index_7 free
+General Constraints
+ GC0: maximum_2 = MAX ( X[0,0] , Y[0,0] , index_1 )
+ GC1: maximum_4 = MAX ( X[0,1] , Y[0,1] , index_3 )
+ GC2: maximum_6 = MAX ( X[1,0] , Y[1,0] , index_5 )
+ GC3: maximum_8 = MAX ( X[1,1] , Y[1,1] , index_7 )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix14__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix14__0.txt
@@ -58,12 +58,9 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_2 + maximum_4 + maximum_6 + maximum_8
+  0 Constant_1 + maximum_2 + 0 Constant_3 + maximum_4 + 0 Constant_5
+   + maximum_6 + 0 Constant_7 + maximum_8
 Subject To
- R0: index_1 = 1
- R1: index_3 = 1
- R2: index_5 = 1
- R3: index_7 = 1
  99[0,0]: X[0,0] >= 1
  99[0,1]: X[0,1] >= 1
  99[1,0]: X[1,0] >= 1
@@ -73,13 +70,13 @@ Subject To
  104[1,0]: Y[1,0] >= 1
  104[1,1]: Y[1,1] >= 1
 Bounds
- index_1 free
- index_3 free
- index_5 free
- index_7 free
+ Constant_1 = 1
+ Constant_3 = 1
+ Constant_5 = 1
+ Constant_7 = 1
 General Constraints
- GC0: maximum_2 = MAX ( X[0,0] , Y[0,0] , index_1 )
- GC1: maximum_4 = MAX ( X[0,1] , Y[0,1] , index_3 )
- GC2: maximum_6 = MAX ( X[1,0] , Y[1,0] , index_5 )
- GC3: maximum_8 = MAX ( X[1,1] , Y[1,1] , index_7 )
+ GC0: maximum_2 = MAX ( X[0,0] , Y[0,0] , Constant_1 )
+ GC1: maximum_4 = MAX ( X[0,1] , Y[0,1] , Constant_3 )
+ GC2: maximum_6 = MAX ( X[1,0] , Y[1,0] , Constant_5 )
+ GC3: maximum_8 = MAX ( X[1,1] , Y[1,1] , Constant_7 )
 End

--- a/tests/snapshots/all__lp_genexpr_matrix1__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix1__0.txt
@@ -1,0 +1,54 @@
+CVXPY
+Minimize
+  Sum(abs(X + Promote(1.0, (2, 2))), None, False)
+Subject To
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 + C4 <= -1
+ R1: - C1 + C5 <= -1
+ R2: - C2 + C6 <= -1
+ R3: - C3 + C7 <= -1
+ R4: - C0 - C4 <= 1
+ R5: - C1 - C5 <= 1
+ R6: - C2 - C6 <= 1
+ R7: - C3 - C7 <= 1
+ R8: - C4 <= 0
+ R9: - C5 <= 0
+ R10: - C6 <= 0
+ R11: - C7 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  abs_2 + abs_4 + abs_6 + abs_8
+Subject To
+ R0: - X[0,0] + index_1 = 1
+ R1: - X[0,1] + index_3 = 1
+ R2: - X[1,0] + index_5 = 1
+ R3: - X[1,1] + index_7 = 1
+Bounds
+ index_1 free
+ index_3 free
+ index_5 free
+ index_7 free
+General Constraints
+ GC0: abs_2 = ABS ( index_1 )
+ GC1: abs_4 = ABS ( index_3 )
+ GC2: abs_6 = ABS ( index_5 )
+ GC3: abs_8 = ABS ( index_7 )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix2__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix2__0.txt
@@ -1,0 +1,63 @@
+CVXPY
+Minimize
+  Sum(abs(X + Y), None, False)
+Subject To
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 + C4 + C8 <= 0
+ R1: - C1 + C5 + C9 <= 0
+ R2: - C2 + C6 + C10 <= 0
+ R3: - C3 + C7 + C11 <= 0
+ R4: - C0 - C4 - C8 <= 0
+ R5: - C1 - C5 - C9 <= 0
+ R6: - C2 - C6 - C10 <= 0
+ R7: - C3 - C7 - C11 <= 0
+ R8: - C4 <= 0
+ R9: - C5 <= 0
+ R10: - C6 <= 0
+ R11: - C7 <= 0
+ R12: - C8 <= 0
+ R13: - C9 <= 0
+ R14: - C10 <= 0
+ R15: - C11 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  abs_2 + abs_4 + abs_6 + abs_8
+Subject To
+ R0: - X[0,0] - Y[0,0] + index_1 = 0
+ R1: - X[0,1] - Y[0,1] + index_3 = 0
+ R2: - X[1,0] - Y[1,0] + index_5 = 0
+ R3: - X[1,1] - Y[1,1] + index_7 = 0
+Bounds
+ index_1 free
+ index_3 free
+ index_5 free
+ index_7 free
+General Constraints
+ GC0: abs_2 = ABS ( index_1 )
+ GC1: abs_4 = ABS ( index_3 )
+ GC2: abs_6 = ABS ( index_5 )
+ GC3: abs_8 = ABS ( index_7 )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix3__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix3__0.txt
@@ -1,0 +1,46 @@
+CVXPY
+Maximize
+  min(X, None, False)
+Subject To
+ 16: X <= 1.0
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 <= 0
+ R1: - C0 - C2 <= 0
+ R2: - C0 - C3 <= 0
+ R3: - C0 - C4 <= 0
+ R4: - C1 <= 0
+ R5: - C2 <= 0
+ R6: - C3 <= 0
+ R7: - C4 <= 0
+ R8: C1 <= 1
+ R9: C2 <= 1
+ R10: C3 <= 1
+ R11: C4 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_1
+Subject To
+ 16[0,0]: X[0,0] <= 1
+ 16[0,1]: X[0,1] <= 1
+ 16[1,0]: X[1,0] <= 1
+ 16[1,1]: X[1,1] <= 1
+Bounds
+ min_1 free
+General Constraints
+ GC0: min_1 = MIN ( X[0,0] , X[0,1] , X[1,0] , X[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix4__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix4__0.txt
@@ -1,0 +1,47 @@
+CVXPY
+Maximize
+  min(X, None, False) + 1.0
+Subject To
+ 23: X <= 1.0
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 <= 0
+ R1: - C0 - C2 <= 0
+ R2: - C0 - C3 <= 0
+ R3: - C0 - C4 <= 0
+ R4: - C1 <= 0
+ R5: - C2 <= 0
+ R6: - C3 <= 0
+ R7: - C4 <= 0
+ R8: C1 <= 1
+ R9: C2 <= 1
+ R10: C3 <= 1
+ R11: C4 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_1 + Constant
+Subject To
+ 23[0,0]: X[0,0] <= 1
+ 23[0,1]: X[0,1] <= 1
+ 23[1,0]: X[1,0] <= 1
+ 23[1,1]: X[1,1] <= 1
+Bounds
+ min_1 free
+ Constant = 1
+General Constraints
+ GC0: min_1 = MIN ( X[0,0] , X[0,1] , X[1,0] , X[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix5__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix5__0.txt
@@ -1,0 +1,71 @@
+CVXPY
+Maximize
+  min(X, None, False) + min(Y, None, False)
+Subject To
+ 31: X <= 1.0
+ 36: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 - C2 <= 0
+ R1: - C0 - C3 <= 0
+ R2: - C0 - C4 <= 0
+ R3: - C0 - C5 <= 0
+ R4: - C1 - C6 <= 0
+ R5: - C1 - C7 <= 0
+ R6: - C1 - C8 <= 0
+ R7: - C1 - C9 <= 0
+ R8: - C2 <= 0
+ R9: - C3 <= 0
+ R10: - C4 <= 0
+ R11: - C5 <= 0
+ R12: - C6 <= 0
+ R13: - C7 <= 0
+ R14: - C8 <= 0
+ R15: - C9 <= 0
+ R16: C2 <= 1
+ R17: C3 <= 1
+ R18: C4 <= 1
+ R19: C5 <= 1
+ R20: C6 <= 1
+ R21: C7 <= 1
+ R22: C8 <= 1
+ R23: C9 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_1 + min_2
+Subject To
+ 31[0,0]: X[0,0] <= 1
+ 31[0,1]: X[0,1] <= 1
+ 31[1,0]: X[1,0] <= 1
+ 31[1,1]: X[1,1] <= 1
+ 36[0,0]: Y[0,0] <= 1
+ 36[0,1]: Y[0,1] <= 1
+ 36[1,0]: Y[1,0] <= 1
+ 36[1,1]: Y[1,1] <= 1
+Bounds
+ min_1 free
+ min_2 free
+General Constraints
+ GC0: min_1 = MIN ( X[0,0] , X[0,1] , X[1,0] , X[1,1] )
+ GC1: min_2 = MIN ( Y[0,0] , Y[0,1] , Y[1,0] , Y[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix6__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix6__0.txt
@@ -1,0 +1,72 @@
+CVXPY
+Maximize
+  min(X + Y, None, False)
+Subject To
+ 43: X <= 1.0
+ 48: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 - C5 <= 0
+ R1: - C0 - C2 - C6 <= 0
+ R2: - C0 - C3 - C7 <= 0
+ R3: - C0 - C4 - C8 <= 0
+ R4: - C1 <= 0
+ R5: - C2 <= 0
+ R6: - C3 <= 0
+ R7: - C4 <= 0
+ R8: - C5 <= 0
+ R9: - C6 <= 0
+ R10: - C7 <= 0
+ R11: - C8 <= 0
+ R12: C1 <= 1
+ R13: C2 <= 1
+ R14: C3 <= 1
+ R15: C4 <= 1
+ R16: C5 <= 1
+ R17: C6 <= 1
+ R18: C7 <= 1
+ R19: C8 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_5
+Subject To
+ R0: - X[0,0] - Y[0,0] + index_1 = 0
+ R1: - X[0,1] - Y[0,1] + index_2 = 0
+ R2: - X[1,0] - Y[1,0] + index_3 = 0
+ R3: - X[1,1] - Y[1,1] + index_4 = 0
+ 43[0,0]: X[0,0] <= 1
+ 43[0,1]: X[0,1] <= 1
+ 43[1,0]: X[1,0] <= 1
+ 43[1,1]: X[1,1] <= 1
+ 48[0,0]: Y[0,0] <= 1
+ 48[0,1]: Y[0,1] <= 1
+ 48[1,0]: Y[1,0] <= 1
+ 48[1,1]: Y[1,1] <= 1
+Bounds
+ index_1 free
+ index_2 free
+ index_3 free
+ index_4 free
+ min_5 free
+General Constraints
+ GC0: min_5 = MIN ( index_1 , index_2 , index_3 , index_4 )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix7__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix7__0.txt
@@ -1,0 +1,37 @@
+CVXPY
+Minimize
+  max(X, None, False)
+Subject To
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 + C2 <= 0
+ R2: - C0 + C3 <= 0
+ R3: - C0 + C4 <= 0
+ R4: - C1 <= 0
+ R5: - C2 <= 0
+ R6: - C3 <= 0
+ R7: - C4 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0,0] + 0 X[0,1] + 0 X[1,0] + 0 X[1,1] + max_1
+Subject To
+Bounds
+ max_1 free
+General Constraints
+ GC0: max_1 = MAX ( X[0,0] , X[0,1] , X[1,0] , X[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix8__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix8__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  max(X, None, False) + 1.0
+Subject To
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 + C2 <= 0
+ R2: - C0 + C3 <= 0
+ R3: - C0 + C4 <= 0
+ R4: - C1 <= 0
+ R5: - C2 <= 0
+ R6: - C3 <= 0
+ R7: - C4 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0,0] + 0 X[0,1] + 0 X[1,0] + 0 X[1,1] + max_1 + Constant
+Subject To
+Bounds
+ max_1 free
+ Constant = 1
+General Constraints
+ GC0: max_1 = MAX ( X[0,0] , X[0,1] , X[1,0] , X[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_matrix9__0.txt
+++ b/tests/snapshots/all__lp_genexpr_matrix9__0.txt
@@ -1,0 +1,54 @@
+CVXPY
+Minimize
+  max(X, None, False) + max(Y, None, False)
+Subject To
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 + C2 <= 0
+ R1: - C0 + C3 <= 0
+ R2: - C0 + C4 <= 0
+ R3: - C0 + C5 <= 0
+ R4: - C1 + C6 <= 0
+ R5: - C1 + C7 <= 0
+ R6: - C1 + C8 <= 0
+ R7: - C1 + C9 <= 0
+ R8: - C2 <= 0
+ R9: - C3 <= 0
+ R10: - C4 <= 0
+ R11: - C5 <= 0
+ R12: - C6 <= 0
+ R13: - C7 <= 0
+ R14: - C8 <= 0
+ R15: - C9 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0,0] + 0 X[0,1] + 0 X[1,0] + 0 X[1,1] + max_1 + 0 Y[0,0] + 0 Y[0,1]
+   + 0 Y[1,0] + 0 Y[1,1] + max_2
+Subject To
+Bounds
+ max_1 free
+ max_2 free
+General Constraints
+ GC0: max_1 = MAX ( X[0,0] , X[0,1] , X[1,0] , X[1,1] )
+ GC1: max_2 = MAX ( Y[0,0] , Y[0,1] , Y[1,0] , Y[1,1] )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar0__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar0__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  abs(x)
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 x + abs_1
+Subject To
+Bounds
+ x free
+ abs_1 free
+General Constraints
+ GC0: abs_1 = ABS ( x )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar0__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar0__0.txt
@@ -23,7 +23,6 @@ Minimize
 Subject To
 Bounds
  x free
- abs_1 free
 General Constraints
  GC0: abs_1 = ABS ( x )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar10__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar10__0.txt
@@ -1,9 +1,9 @@
 CVXPY
 Minimize
-  maximum(x, y)
+  maximum(x + y, 1.0)
 Subject To
- 52: 0.0 <= x
- 56: 0.0 <= y
+ 62: 0.0 <= x
+ 66: 0.0 <= y
 Bounds
  x free
  y free
@@ -13,8 +13,8 @@ AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 + C1 <= 0
- R1: - C0 + C2 <= 0
+ R0: - C0 + C1 + C2 <= 0
+ R1: - C0 <= -1
  R2: - C1 <= 0
  R3: - C2 <= 0
 Bounds
@@ -25,13 +25,17 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_1
+  maximum_3
 Subject To
- 52: x >= 0
- 56: y >= 0
+ R0: - x - y + AddExpression_1 = 0
+ R1: Constant_2 = 1
+ 62: x >= 0
+ 66: y >= 0
 Bounds
  x free
  y free
+ AddExpression_1 free
+ Constant_2 free
 General Constraints
- GC0: maximum_1 = MAX ( x , y )
+ GC0: maximum_3 = MAX ( AddExpression_1 , Constant_2 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar10__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar10__0.txt
@@ -25,17 +25,16 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_3
+  0 Constant_2 + maximum_3
 Subject To
  R0: - x - y + AddExpression_1 = 0
- R1: Constant_2 = 1
  62: x >= 0
  66: y >= 0
 Bounds
  x free
  y free
  AddExpression_1 free
- Constant_2 free
+ Constant_2 = 1
 General Constraints
  GC0: maximum_3 = MAX ( AddExpression_1 , Constant_2 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar11__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar11__0.txt
@@ -26,15 +26,14 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_2
+  0 Constant_1 + maximum_2
 Subject To
- R0: Constant_1 = 1
  71: x >= 0
  75: y >= 0
 Bounds
  x free
  y free
- Constant_1 free
+ Constant_1 = 1
 General Constraints
  GC0: maximum_2 = MAX ( x , y , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar11__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar11__0.txt
@@ -1,9 +1,9 @@
 CVXPY
 Minimize
-  maximum(x, y)
+  maximum(x, y, 1.0)
 Subject To
- 52: 0.0 <= x
- 56: 0.0 <= y
+ 71: 0.0 <= x
+ 75: 0.0 <= y
 Bounds
  x free
  y free
@@ -15,8 +15,9 @@ Minimize
 Subject To
  R0: - C0 + C1 <= 0
  R1: - C0 + C2 <= 0
- R2: - C1 <= 0
- R3: - C2 <= 0
+ R2: - C0 <= -1
+ R3: - C1 <= 0
+ R4: - C2 <= 0
 Bounds
  C0 free
  C1 free
@@ -25,13 +26,15 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_1
+  maximum_2
 Subject To
- 52: x >= 0
- 56: y >= 0
+ R0: Constant_1 = 1
+ 71: x >= 0
+ 75: y >= 0
 Bounds
  x free
  y free
+ Constant_1 free
 General Constraints
- GC0: maximum_1 = MAX ( x , y )
+ GC0: maximum_2 = MAX ( x , y , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar1__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar1__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  abs(x) + 1.0
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 - C1 <= 0
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 x + abs_1 + Constant
+Subject To
+Bounds
+ x free
+ abs_1 free
+ Constant = 1
+General Constraints
+ GC0: abs_1 = ABS ( x )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar1__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar1__0.txt
@@ -23,7 +23,6 @@ Minimize
 Subject To
 Bounds
  x free
- abs_1 free
  Constant = 1
 General Constraints
  GC0: abs_1 = ABS ( x )

--- a/tests/snapshots/all__lp_genexpr_scalar2__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar2__0.txt
@@ -28,9 +28,7 @@ Minimize
 Subject To
 Bounds
  x free
- abs_1 free
  y free
- abs_2 free
 General Constraints
  GC0: abs_1 = ABS ( x )
  GC1: abs_2 = ABS ( y )

--- a/tests/snapshots/all__lp_genexpr_scalar2__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar2__0.txt
@@ -1,0 +1,37 @@
+CVXPY
+Minimize
+  abs(x) + abs(y)
+Subject To
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 + C2 <= 0
+ R1: - C0 - C2 <= 0
+ R2: - C1 + C3 <= 0
+ R3: - C1 - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 x + abs_1 + 0 y + abs_2
+Subject To
+Bounds
+ x free
+ abs_1 free
+ y free
+ abs_2 free
+General Constraints
+ GC0: abs_1 = ABS ( x )
+ GC1: abs_2 = ABS ( y )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar3__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar3__0.txt
@@ -27,7 +27,7 @@ Subject To
 Bounds
  x free
  y free
- abs_2 free
+ AddExpression_1 free
 General Constraints
  GC0: abs_2 = ABS ( AddExpression_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar3__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar3__0.txt
@@ -1,0 +1,33 @@
+CVXPY
+Minimize
+  abs(x + y)
+Subject To
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 + C2 <= 0
+ R1: - C0 - C1 - C2 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  abs_2
+Subject To
+ R0: - x - y + AddExpression_1 = 0
+Bounds
+ x free
+ y free
+ abs_2 free
+General Constraints
+ GC0: abs_2 = ABS ( AddExpression_1 )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar4__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar4__0.txt
@@ -1,0 +1,34 @@
+CVXPY
+Maximize
+  minimum(x, 2.0)
+Subject To
+ 14: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 <= 0
+ R1: - C0 <= 2
+ R2: C1 <= 1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  minimum_2
+Subject To
+ R0: Constant_1 = 2
+ 14: x <= 1
+Bounds
+ x free
+ Constant_1 free
+ minimum_2 free
+General Constraints
+ GC0: minimum_2 = MIN ( x , Constant_1 )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar4__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar4__0.txt
@@ -28,7 +28,6 @@ Subject To
 Bounds
  x free
  Constant_1 free
- minimum_2 free
 General Constraints
  GC0: minimum_2 = MIN ( x , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar4__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar4__0.txt
@@ -21,13 +21,12 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  minimum_2
+  0 Constant_1 + minimum_2
 Subject To
- R0: Constant_1 = 2
  14: x <= 1
 Bounds
  x free
- Constant_1 free
+ Constant_1 = 2
 General Constraints
  GC0: minimum_2 = MIN ( x , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar5__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar5__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Maximize
+  minimum(x, y)
+Subject To
+ 19: x <= 1.0
+ 23: y <= 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 <= 0
+ R1: - C0 - C2 <= 0
+ R2: C1 <= 1
+ R3: C2 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  minimum_1
+Subject To
+ 19: x <= 1
+ 23: y <= 1
+Bounds
+ x free
+ y free
+ minimum_1 free
+General Constraints
+ GC0: minimum_1 = MIN ( x , y )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar5__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar5__0.txt
@@ -32,7 +32,6 @@ Subject To
 Bounds
  x free
  y free
- minimum_1 free
 General Constraints
  GC0: minimum_1 = MIN ( x , y )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar6__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar6__0.txt
@@ -1,0 +1,42 @@
+CVXPY
+Maximize
+  minimum(x + y, 1.0)
+Subject To
+ 29: x <= 1.0
+ 33: y <= 1.0
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 - C2 <= 0
+ R1: - C0 <= 1
+ R2: C1 <= 1
+ R3: C2 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  minimum_3
+Subject To
+ R0: - x - y + AddExpression_1 = 0
+ R1: Constant_2 = 1
+ 29: x <= 1
+ 33: y <= 1
+Bounds
+ x free
+ y free
+ AddExpression_1 free
+ Constant_2 free
+ minimum_3 free
+General Constraints
+ GC0: minimum_3 = MIN ( AddExpression_1 , Constant_2 )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar6__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar6__0.txt
@@ -25,17 +25,16 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  minimum_3
+  0 Constant_2 + minimum_3
 Subject To
  R0: - x - y + AddExpression_1 = 0
- R1: Constant_2 = 1
  29: x <= 1
  33: y <= 1
 Bounds
  x free
  y free
  AddExpression_1 free
- Constant_2 free
+ Constant_2 = 1
 General Constraints
  GC0: minimum_3 = MIN ( AddExpression_1 , Constant_2 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar6__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar6__0.txt
@@ -36,7 +36,6 @@ Bounds
  y free
  AddExpression_1 free
  Constant_2 free
- minimum_3 free
 General Constraints
  GC0: minimum_3 = MIN ( AddExpression_1 , Constant_2 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar7__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar7__0.txt
@@ -26,15 +26,14 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  minimum_2
+  0 Constant_1 + minimum_2
 Subject To
- R0: Constant_1 = 1
  38: x <= 1
  42: y <= 1
 Bounds
  x free
  y free
- Constant_1 free
+ Constant_1 = 1
 General Constraints
  GC0: minimum_2 = MIN ( x , y , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar7__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar7__0.txt
@@ -1,34 +1,40 @@
 CVXPY
-Minimize
-  maximum(x, 1.0)
+Maximize
+  minimum(x, y, 1.0)
 Subject To
- 38: 2.0 <= x
+ 38: x <= 1.0
+ 42: y <= 1.0
 Bounds
  x free
+ y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
   C0
 Subject To
- R0: - C0 + C1 <= 0
- R1: - C0 <= -1
- R2: - C1 <= -2
+ R0: - C0 - C1 <= 0
+ R1: - C0 - C2 <= 0
+ R2: - C0 <= 1
+ R3: C1 <= 1
+ R4: C2 <= 1
 Bounds
  C0 free
  C1 free
+ C2 free
 End
 ----------------------------------------
 GUROBI
-Minimize
-  maximum_2
+Maximize
+  minimum_2
 Subject To
  R0: Constant_1 = 1
- 38: x >= 2
+ 38: x <= 1
+ 42: y <= 1
 Bounds
  x free
+ y free
  Constant_1 free
- maximum_2 free
 General Constraints
- GC0: maximum_2 = MAX ( x , Constant_1 )
+ GC0: minimum_2 = MIN ( x , y , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar7__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar7__0.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  maximum(x, 1.0)
+Subject To
+ 38: 2.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 <= -1
+ R2: - C1 <= -2
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  maximum_2
+Subject To
+ R0: Constant_1 = 1
+ 38: x >= 2
+Bounds
+ x free
+ Constant_1 free
+ maximum_2 free
+General Constraints
+ GC0: maximum_2 = MAX ( x , Constant_1 )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar8__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar8__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  maximum(x, y)
+Subject To
+ 43: 0.0 <= x
+ 47: 0.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 + C2 <= 0
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  maximum_1
+Subject To
+ 43: x >= 0
+ 47: y >= 0
+Bounds
+ x free
+ y free
+ maximum_1 free
+General Constraints
+ GC0: maximum_1 = MAX ( x , y )
+End

--- a/tests/snapshots/all__lp_genexpr_scalar8__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar8__0.txt
@@ -1,12 +1,10 @@
 CVXPY
 Minimize
-  maximum(x, y)
+  maximum(x, 1.0)
 Subject To
- 43: 0.0 <= x
- 47: 0.0 <= y
+ 47: 2.0 <= x
 Bounds
  x free
- y free
 End
 ----------------------------------------
 AFTER COMPILATION
@@ -14,25 +12,22 @@ Minimize
   C0
 Subject To
  R0: - C0 + C1 <= 0
- R1: - C0 + C2 <= 0
- R2: - C1 <= 0
- R3: - C2 <= 0
+ R1: - C0 <= -1
+ R2: - C1 <= -2
 Bounds
  C0 free
  C1 free
- C2 free
 End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_1
+  maximum_2
 Subject To
- 43: x >= 0
- 47: y >= 0
+ R0: Constant_1 = 1
+ 47: x >= 2
 Bounds
  x free
- y free
- maximum_1 free
+ Constant_1 free
 General Constraints
- GC0: maximum_1 = MAX ( x , y )
+ GC0: maximum_2 = MAX ( x , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar8__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar8__0.txt
@@ -21,13 +21,12 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_2
+  0 Constant_1 + maximum_2
 Subject To
- R0: Constant_1 = 1
  47: x >= 2
 Bounds
  x free
- Constant_1 free
+ Constant_1 = 1
 General Constraints
  GC0: maximum_2 = MAX ( x , Constant_1 )
 End

--- a/tests/snapshots/all__lp_genexpr_scalar9__0.txt
+++ b/tests/snapshots/all__lp_genexpr_scalar9__0.txt
@@ -1,0 +1,42 @@
+CVXPY
+Minimize
+  maximum(x + y, 1.0)
+Subject To
+ 53: 0.0 <= x
+ 57: 0.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 + C2 <= 0
+ R1: - C0 <= -1
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  maximum_3
+Subject To
+ R0: - x - y + AddExpression_1 = 0
+ R1: Constant_2 = 1
+ 53: x >= 0
+ 57: y >= 0
+Bounds
+ x free
+ y free
+ AddExpression_1 free
+ Constant_2 free
+ maximum_3 free
+General Constraints
+ GC0: maximum_3 = MAX ( AddExpression_1 , Constant_2 )
+End

--- a/tests/snapshots/all__lp_genexpr_vector0__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector0__0.txt
@@ -1,0 +1,36 @@
+CVXPY
+Minimize
+  Sum(abs(X), None, False)
+Subject To
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 + C2 <= 0
+ R1: - C1 + C3 <= 0
+ R2: - C0 - C2 <= 0
+ R3: - C1 - C3 <= 0
+ R4: - C2 <= 0
+ R5: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0] + 0 X[1] + abs_1 + abs_2
+Subject To
+Bounds
+ abs_1 free
+ abs_2 free
+General Constraints
+ GC0: abs_1 = ABS ( X[0] )
+ GC1: abs_2 = ABS ( X[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector0__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector0__0.txt
@@ -28,8 +28,6 @@ Minimize
   0 X[0] + 0 X[1] + abs_1 + abs_2
 Subject To
 Bounds
- abs_1 free
- abs_2 free
 General Constraints
  GC0: abs_1 = ABS ( X[0] )
  GC1: abs_2 = ABS ( X[1] )

--- a/tests/snapshots/all__lp_genexpr_vector10__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector10__0.txt
@@ -1,0 +1,49 @@
+CVXPY
+Maximize
+  Sum(minimum(X, Y), None, False)
+Subject To
+ 59: X <= 1.0
+ 64: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 - C2 <= 0
+ R1: - C1 - C3 <= 0
+ R2: - C0 - C4 <= 0
+ R3: - C1 - C5 <= 0
+ R4: - C2 <= 0
+ R5: - C3 <= 0
+ R6: - C4 <= 0
+ R7: - C5 <= 0
+ R8: C2 <= 1
+ R9: C3 <= 1
+ R10: C4 <= 1
+ R11: C5 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  minimum_1 + minimum_2
+Subject To
+ 59[0]: X[0] <= 1
+ 59[1]: X[1] <= 1
+ 64[0]: Y[0] <= 1
+ 64[1]: Y[1] <= 1
+Bounds
+General Constraints
+ GC0: minimum_1 = MIN ( X[0] , Y[0] )
+ GC1: minimum_2 = MIN ( X[1] , Y[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector11__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector11__0.txt
@@ -1,0 +1,55 @@
+CVXPY
+Maximize
+  Sum(minimum(X, Y, 1.0), None, False)
+Subject To
+ 71: X <= 1.0
+ 76: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 - C2 <= 0
+ R1: - C1 - C3 <= 0
+ R2: - C0 - C4 <= 0
+ R3: - C1 - C5 <= 0
+ R4: - C0 <= 1
+ R5: - C1 <= 1
+ R6: - C2 <= 0
+ R7: - C3 <= 0
+ R8: - C4 <= 0
+ R9: - C5 <= 0
+ R10: C2 <= 1
+ R11: C3 <= 1
+ R12: C4 <= 1
+ R13: C5 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  minimum_2 + minimum_4
+Subject To
+ R0: index_1 = 1
+ R1: index_3 = 1
+ 71[0]: X[0] <= 1
+ 71[1]: X[1] <= 1
+ 76[0]: Y[0] <= 1
+ 76[1]: Y[1] <= 1
+Bounds
+ index_1 free
+ index_3 free
+General Constraints
+ GC0: minimum_2 = MIN ( X[0] , Y[0] , index_1 )
+ GC1: minimum_4 = MIN ( X[1] , Y[1] , index_3 )
+End

--- a/tests/snapshots/all__lp_genexpr_vector11__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector11__0.txt
@@ -38,18 +38,16 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  minimum_2 + minimum_4
+  0 Constant_1 + minimum_2 + 0 Constant_3 + minimum_4
 Subject To
- R0: index_1 = 1
- R1: index_3 = 1
  71[0]: X[0] <= 1
  71[1]: X[1] <= 1
  76[0]: Y[0] <= 1
  76[1]: Y[1] <= 1
 Bounds
- index_1 free
- index_3 free
+ Constant_1 = 1
+ Constant_3 = 1
 General Constraints
- GC0: minimum_2 = MIN ( X[0] , Y[0] , index_1 )
- GC1: minimum_4 = MIN ( X[1] , Y[1] , index_3 )
+ GC0: minimum_2 = MIN ( X[0] , Y[0] , Constant_1 )
+ GC1: minimum_4 = MIN ( X[1] , Y[1] , Constant_3 )
 End

--- a/tests/snapshots/all__lp_genexpr_vector12__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector12__0.txt
@@ -1,0 +1,49 @@
+CVXPY
+Minimize
+  Sum(maximum(X, Y), None, False)
+Subject To
+ 83: 1.0 <= X
+ 88: 1.0 <= Y
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 + C2 <= 0
+ R1: - C1 + C3 <= 0
+ R2: - C0 + C4 <= 0
+ R3: - C1 + C5 <= 0
+ R4: - C2 <= 0
+ R5: - C3 <= 0
+ R6: - C4 <= 0
+ R7: - C5 <= 0
+ R8: - C2 <= -1
+ R9: - C3 <= -1
+ R10: - C4 <= -1
+ R11: - C5 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  maximum_1 + maximum_2
+Subject To
+ 83[0]: X[0] >= 1
+ 83[1]: X[1] >= 1
+ 88[0]: Y[0] >= 1
+ 88[1]: Y[1] >= 1
+Bounds
+General Constraints
+ GC0: maximum_1 = MAX ( X[0] , Y[0] )
+ GC1: maximum_2 = MAX ( X[1] , Y[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector13__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector13__0.txt
@@ -38,18 +38,16 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  maximum_2 + maximum_4
+  0 Constant_1 + maximum_2 + 0 Constant_3 + maximum_4
 Subject To
- R0: index_1 = 1
- R1: index_3 = 1
  95[0]: X[0] >= 1
  95[1]: X[1] >= 1
  100[0]: Y[0] >= 1
  100[1]: Y[1] >= 1
 Bounds
- index_1 free
- index_3 free
+ Constant_1 = 1
+ Constant_3 = 1
 General Constraints
- GC0: maximum_2 = MAX ( X[0] , Y[0] , index_1 )
- GC1: maximum_4 = MAX ( X[1] , Y[1] , index_3 )
+ GC0: maximum_2 = MAX ( X[0] , Y[0] , Constant_1 )
+ GC1: maximum_4 = MAX ( X[1] , Y[1] , Constant_3 )
 End

--- a/tests/snapshots/all__lp_genexpr_vector13__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector13__0.txt
@@ -1,0 +1,55 @@
+CVXPY
+Minimize
+  Sum(maximum(X, Y, 1.0), None, False)
+Subject To
+ 95: 1.0 <= X
+ 100: 1.0 <= Y
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 + C2 <= 0
+ R1: - C1 + C3 <= 0
+ R2: - C0 + C4 <= 0
+ R3: - C1 + C5 <= 0
+ R4: - C0 <= -1
+ R5: - C1 <= -1
+ R6: - C2 <= 0
+ R7: - C3 <= 0
+ R8: - C4 <= 0
+ R9: - C5 <= 0
+ R10: - C2 <= -1
+ R11: - C3 <= -1
+ R12: - C4 <= -1
+ R13: - C5 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  maximum_2 + maximum_4
+Subject To
+ R0: index_1 = 1
+ R1: index_3 = 1
+ 95[0]: X[0] >= 1
+ 95[1]: X[1] >= 1
+ 100[0]: Y[0] >= 1
+ 100[1]: Y[1] >= 1
+Bounds
+ index_1 free
+ index_3 free
+General Constraints
+ GC0: maximum_2 = MAX ( X[0] , Y[0] , index_1 )
+ GC1: maximum_4 = MAX ( X[1] , Y[1] , index_3 )
+End

--- a/tests/snapshots/all__lp_genexpr_vector1__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector1__0.txt
@@ -1,0 +1,43 @@
+CVXPY
+Minimize
+  Sum(abs(X + Y), None, False)
+Subject To
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 + C2 + C4 <= 0
+ R1: - C1 + C3 + C5 <= 0
+ R2: - C0 - C2 - C4 <= 0
+ R3: - C1 - C3 - C5 <= 0
+ R4: - C2 <= 0
+ R5: - C3 <= 0
+ R6: - C4 <= 0
+ R7: - C5 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  abs_2 + abs_4
+Subject To
+ R0: - X[0] - Y[0] + index_1 = 0
+ R1: - X[1] - Y[1] + index_3 = 0
+Bounds
+ abs_2 free
+ abs_4 free
+General Constraints
+ GC0: abs_2 = ABS ( index_1 )
+ GC1: abs_4 = ABS ( index_3 )
+End

--- a/tests/snapshots/all__lp_genexpr_vector1__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector1__0.txt
@@ -35,8 +35,8 @@ Subject To
  R0: - X[0] - Y[0] + index_1 = 0
  R1: - X[1] - Y[1] + index_3 = 0
 Bounds
- abs_2 free
- abs_4 free
+ index_1 free
+ index_3 free
 General Constraints
  GC0: abs_2 = ABS ( index_1 )
  GC1: abs_4 = ABS ( index_3 )

--- a/tests/snapshots/all__lp_genexpr_vector2__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector2__0.txt
@@ -1,0 +1,36 @@
+CVXPY
+Maximize
+  min(X, None, False)
+Subject To
+ 12: X <= 1.0
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 <= 0
+ R1: - C0 - C2 <= 0
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+ R4: C1 <= 1
+ R5: C2 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_1
+Subject To
+ 12[0]: X[0] <= 1
+ 12[1]: X[1] <= 1
+Bounds
+ min_1 free
+General Constraints
+ GC0: min_1 = MIN ( X[0] , X[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector3__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector3__0.txt
@@ -1,0 +1,37 @@
+CVXPY
+Maximize
+  min(X, None, False) + 1.0
+Subject To
+ 19: X <= 1.0
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 <= 0
+ R1: - C0 - C2 <= 0
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+ R4: C1 <= 1
+ R5: C2 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_1 + Constant
+Subject To
+ 19[0]: X[0] <= 1
+ 19[1]: X[1] <= 1
+Bounds
+ min_1 free
+ Constant = 1
+General Constraints
+ GC0: min_1 = MIN ( X[0] , X[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector4__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector4__0.txt
@@ -1,0 +1,51 @@
+CVXPY
+Maximize
+  min(X, None, False) + min(Y, None, False)
+Subject To
+ 27: X <= 1.0
+ 32: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 - C2 <= 0
+ R1: - C0 - C3 <= 0
+ R2: - C1 - C4 <= 0
+ R3: - C1 - C5 <= 0
+ R4: - C2 <= 0
+ R5: - C3 <= 0
+ R6: - C4 <= 0
+ R7: - C5 <= 0
+ R8: C2 <= 1
+ R9: C3 <= 1
+ R10: C4 <= 1
+ R11: C5 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_1 + min_2
+Subject To
+ 27[0]: X[0] <= 1
+ 27[1]: X[1] <= 1
+ 32[0]: Y[0] <= 1
+ 32[1]: Y[1] <= 1
+Bounds
+ min_1 free
+ min_2 free
+General Constraints
+ GC0: min_1 = MIN ( X[0] , X[1] )
+ GC1: min_2 = MIN ( Y[0] , Y[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector5__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector5__0.txt
@@ -1,0 +1,50 @@
+CVXPY
+Maximize
+  min(X + Y, None, False)
+Subject To
+ 39: X <= 1.0
+ 44: Y <= 1.0
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 - C1 - C3 <= 0
+ R1: - C0 - C2 - C4 <= 0
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+ R4: - C3 <= 0
+ R5: - C4 <= 0
+ R6: C1 <= 1
+ R7: C2 <= 1
+ R8: C3 <= 1
+ R9: C4 <= 1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  min_3
+Subject To
+ R0: - X[0] - Y[0] + index_1 = 0
+ R1: - X[1] - Y[1] + index_2 = 0
+ 39[0]: X[0] <= 1
+ 39[1]: X[1] <= 1
+ 44[0]: Y[0] <= 1
+ 44[1]: Y[1] <= 1
+Bounds
+ index_1 free
+ index_2 free
+ min_3 free
+General Constraints
+ GC0: min_3 = MIN ( index_1 , index_2 )
+End

--- a/tests/snapshots/all__lp_genexpr_vector6__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector6__0.txt
@@ -1,0 +1,31 @@
+CVXPY
+Minimize
+  max(X, None, False)
+Subject To
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 + C2 <= 0
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0] + 0 X[1] + max_1
+Subject To
+Bounds
+ max_1 free
+General Constraints
+ GC0: max_1 = MAX ( X[0] , X[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector7__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector7__0.txt
@@ -1,0 +1,32 @@
+CVXPY
+Minimize
+  max(X, None, False) + 1.0
+Subject To
+Bounds
+ 0.0 <= X
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 <= 0
+ R1: - C0 + C2 <= 0
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0] + 0 X[1] + max_1 + Constant
+Subject To
+Bounds
+ max_1 free
+ Constant = 1
+General Constraints
+ GC0: max_1 = MAX ( X[0] , X[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector8__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector8__0.txt
@@ -1,0 +1,41 @@
+CVXPY
+Minimize
+  max(X, None, False) + max(Y, None, False)
+Subject To
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 + C2 <= 0
+ R1: - C0 + C3 <= 0
+ R2: - C1 + C4 <= 0
+ R3: - C1 + C5 <= 0
+ R4: - C2 <= 0
+ R5: - C3 <= 0
+ R6: - C4 <= 0
+ R7: - C5 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  0 X[0] + 0 X[1] + max_1 + 0 Y[0] + 0 Y[1] + max_2
+Subject To
+Bounds
+ max_1 free
+ max_2 free
+General Constraints
+ GC0: max_1 = MAX ( X[0] , X[1] )
+ GC1: max_2 = MAX ( Y[0] , Y[1] )
+End

--- a/tests/snapshots/all__lp_genexpr_vector9__0.txt
+++ b/tests/snapshots/all__lp_genexpr_vector9__0.txt
@@ -1,0 +1,40 @@
+CVXPY
+Minimize
+  max(X + Y, None, False)
+Subject To
+Bounds
+ 0.0 <= X
+ 0.0 <= Y
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 + C1 + C3 <= 0
+ R1: - C0 + C2 + C4 <= 0
+ R2: - C1 <= 0
+ R3: - C2 <= 0
+ R4: - C3 <= 0
+ R5: - C4 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  max_3
+Subject To
+ R0: - X[0] - Y[0] + index_1 = 0
+ R1: - X[1] - Y[1] + index_2 = 0
+Bounds
+ index_1 free
+ index_2 free
+ max_3 free
+General Constraints
+ GC0: max_3 = MAX ( index_1 , index_2 )
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -42,6 +42,8 @@ def all_problems() -> Iterator[ProblemTestCase]:
         quadratic_expressions,
         matrix_constraints,
         matrix_quadratic_expressions,
+        generalized_scalar_expressions,
+        generalized_vector_expressions,
         indexing,
         attributes,
         invalid_expressions,
@@ -166,6 +168,44 @@ def matrix_quadratic_expressions() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum_squares(S @ x)))
 
 
+@group_cases("genexpr_scalar")
+def generalized_scalar_expressions() -> Iterator[cp.Problem]:
+    x = cp.Variable(name="x")
+    y = cp.Variable(name="y")
+
+    yield cp.Problem(cp.Minimize(cp.abs(x)))
+    yield cp.Problem(cp.Minimize(cp.abs(x) + 1))
+    yield cp.Problem(cp.Minimize(cp.abs(x) + cp.abs(y)))
+    yield cp.Problem(cp.Minimize(cp.abs(x + y)))
+
+    yield cp.Problem(cp.Maximize(cp.minimum(x, 2)), [x <= 1])
+    yield cp.Problem(cp.Maximize(cp.minimum(x, y)), [x <= 1, y <= 1])
+    yield cp.Problem(cp.Maximize(cp.minimum(x + y, 1)), [x <= 1, y <= 1])
+
+    yield cp.Problem(cp.Minimize(cp.maximum(x, 1)), [x >= 2])
+    yield cp.Problem(cp.Minimize(cp.maximum(x, y)), [x >= 0, y >= 0])
+    yield cp.Problem(cp.Minimize(cp.maximum(x + y, 1)), [x >= 0, y >= 0])
+
+
+@group_cases("genexpr_vector")
+def generalized_vector_expressions() -> Iterator[cp.Problem]:
+    X = cp.Variable(2, name="X", nonneg=True)
+    Y = cp.Variable(2, name="Y", nonneg=True)
+
+    yield cp.Problem(cp.Minimize(cp.sum(cp.abs(X))))
+    yield cp.Problem(cp.Minimize(cp.sum(cp.abs(X + Y))))
+
+    yield cp.Problem(cp.Maximize(cp.min(X)), [X <= 1])
+    yield cp.Problem(cp.Maximize(cp.min(X) + 1), [X <= 1])
+    yield cp.Problem(cp.Maximize(cp.min(X) + cp.min(Y)), [X <= 1, Y <= 1])
+    yield cp.Problem(cp.Maximize(cp.min(X + Y)), [X <= 1, Y <= 1])
+
+    yield cp.Problem(cp.Minimize(cp.max(X)))
+    yield cp.Problem(cp.Minimize(cp.max(X) + 1))
+    yield cp.Problem(cp.Minimize(cp.max(X) + cp.max(Y)))
+    yield cp.Problem(cp.Minimize(cp.max(X + Y)))
+
+
 @group_cases("indexing")
 def indexing() -> Iterator[cp.Problem]:
     x = cp.Variable(2, name="x", nonneg=True)
@@ -220,8 +260,6 @@ def invalid_expressions() -> Iterator[cp.Problem]:
     x = cp.Variable(name="x")
     yield cp.Problem(cp.Minimize(x**3))
     yield cp.Problem(cp.Minimize(x**4))
-    # TODO: maybe using setPWLObj?
-    yield cp.Problem(cp.Minimize(cp.abs(x)))
     yield cp.Problem(cp.Maximize(cp.sqrt(x)))
 
 

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -182,10 +182,12 @@ def generalized_scalar_expressions() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Maximize(cp.minimum(x, 2)), [x <= 1])
     yield cp.Problem(cp.Maximize(cp.minimum(x, y)), [x <= 1, y <= 1])
     yield cp.Problem(cp.Maximize(cp.minimum(x + y, 1)), [x <= 1, y <= 1])
+    yield cp.Problem(cp.Maximize(cp.minimum(x, y, 1)), [x <= 1, y <= 1])
 
     yield cp.Problem(cp.Minimize(cp.maximum(x, 1)), [x >= 2])
     yield cp.Problem(cp.Minimize(cp.maximum(x, y)), [x >= 0, y >= 0])
     yield cp.Problem(cp.Minimize(cp.maximum(x + y, 1)), [x >= 0, y >= 0])
+    yield cp.Problem(cp.Minimize(cp.maximum(x, y, 1)), [x >= 0, y >= 0])
 
 
 @group_cases("genexpr_vector")
@@ -206,6 +208,12 @@ def generalized_vector_expressions() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.max(X) + cp.max(Y)))
     yield cp.Problem(cp.Minimize(cp.max(X + Y)))
 
+    yield cp.Problem(cp.Maximize(cp.sum(cp.minimum(X, Y))), [X <= 1, Y <= 1])
+    yield cp.Problem(cp.Maximize(cp.sum(cp.minimum(X, Y, 1))), [X <= 1, Y <= 1])
+
+    yield cp.Problem(cp.Minimize(cp.sum(cp.maximum(X, Y))), [X >= 1, Y >= 1])
+    yield cp.Problem(cp.Minimize(cp.sum(cp.maximum(X, Y, 1))), [X >= 1, Y >= 1])
+
 
 @group_cases("genexpr_matrix")
 def generalized_matrix_expressions() -> Iterator[cp.Problem]:
@@ -225,6 +233,12 @@ def generalized_matrix_expressions() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.max(X) + 1))
     yield cp.Problem(cp.Minimize(cp.max(X) + cp.max(Y)))
     yield cp.Problem(cp.Minimize(cp.max(X + Y)))
+
+    yield cp.Problem(cp.Maximize(cp.sum(cp.minimum(X, Y))), [X <= 1, Y <= 1])
+    yield cp.Problem(cp.Maximize(cp.sum(cp.minimum(X, Y, 1))), [X <= 1, Y <= 1])
+
+    yield cp.Problem(cp.Minimize(cp.sum(cp.maximum(X, Y))), [X >= 1, Y >= 1])
+    yield cp.Problem(cp.Minimize(cp.sum(cp.maximum(X, Y, 1))), [X >= 1, Y >= 1])
 
 
 @group_cases("indexing")

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -44,6 +44,7 @@ def all_problems() -> Iterator[ProblemTestCase]:
         matrix_quadratic_expressions,
         generalized_scalar_expressions,
         generalized_vector_expressions,
+        generalized_matrix_expressions,
         indexing,
         attributes,
         invalid_expressions,
@@ -193,6 +194,26 @@ def generalized_vector_expressions() -> Iterator[cp.Problem]:
     Y = cp.Variable(2, name="Y", nonneg=True)
 
     yield cp.Problem(cp.Minimize(cp.sum(cp.abs(X))))
+    yield cp.Problem(cp.Minimize(cp.sum(cp.abs(X + Y))))
+
+    yield cp.Problem(cp.Maximize(cp.min(X)), [X <= 1])
+    yield cp.Problem(cp.Maximize(cp.min(X) + 1), [X <= 1])
+    yield cp.Problem(cp.Maximize(cp.min(X) + cp.min(Y)), [X <= 1, Y <= 1])
+    yield cp.Problem(cp.Maximize(cp.min(X + Y)), [X <= 1, Y <= 1])
+
+    yield cp.Problem(cp.Minimize(cp.max(X)))
+    yield cp.Problem(cp.Minimize(cp.max(X) + 1))
+    yield cp.Problem(cp.Minimize(cp.max(X) + cp.max(Y)))
+    yield cp.Problem(cp.Minimize(cp.max(X + Y)))
+
+
+@group_cases("genexpr_matrix")
+def generalized_matrix_expressions() -> Iterator[cp.Problem]:
+    X = cp.Variable((2, 2), name="X", nonneg=True)
+    Y = cp.Variable((2, 2), name="Y", nonneg=True)
+
+    yield cp.Problem(cp.Minimize(cp.sum(cp.abs(X))))
+    yield cp.Problem(cp.Minimize(cp.sum(cp.abs(X + 1))))
     yield cp.Problem(cp.Minimize(cp.sum(cp.abs(X + Y))))
 
     yield cp.Problem(cp.Maximize(cp.min(X)), [X <= 1])


### PR DESCRIPTION
Handles the first generalized expressions. It covers `minimum` and `maximum` which use the `gp.min_` and `gp.max_` helper functions as well.

In each case, one or more auxilliary variables are added to the model and their value is constrained to the value of the argument of the atom. This is necessary because gurobipy's helper function operate on variables, not on arbitrary expressions.