### PR TITLE
Update fixtures for CVXPY v1.5.3 and NumPy v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ build.hooks.vcs.version-file = "src/cvxpy_gurobi/_version.py"
 
 [tool.hatch.envs.default]
 dependencies = [
-  "cvxpy-base==1.5.2",
-  "gurobipy==11.0.0",
-  "numpy<2",  # as of cvxpy 1.5.2, the gurobi interface is not compatible with numpy 2
+  "cvxpy-base==1.5.*",
+  "gurobipy==11.*",
+  "numpy",
   "pytest",
   "pytest-insta",
 ]
@@ -72,7 +72,7 @@ versions = [
 dependencies = [
   "cvxpy-base=={matrix:cvxpy}.*",
   "gurobipy=={matrix:gurobipy}.*",
-  "numpy<2",  # as of cvxpy 1.5.2, the gurobi interface is not compatible with numpy 2
+  "numpy",
   "scipy{matrix:scipy:}",
   "coverage[toml]",
   "pytest",

--- a/tests/snapshots/all__lp_matrix10__0.txt
+++ b/tests/snapshots/all__lp_matrix10__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 91: [[0.0 1.0]
- [2.0 3.0]] @ x + y == 1.0
+ 91: [[np.float64(0.0) np.float64(1.0)]
+ [np.float64(2.0) np.float64(3.0)]] @ x + y == 1.0
 Bounds
  x free
  y free

--- a/tests/snapshots/all__lp_matrix11__0.txt
+++ b/tests/snapshots/all__lp_matrix11__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 101: [[0.0 1.0]
- [2.0 3.0]] @ x + y + Promote(1.0, (2,)) == 0.0
+ 101: [[np.float64(0.0) np.float64(1.0)]
+ [np.float64(2.0) np.float64(3.0)]] @ x + y + Promote(1.0, (2,)) == 0.0
 Bounds
  x free
  y free

--- a/tests/snapshots/all__lp_matrix9__0.txt
+++ b/tests/snapshots/all__lp_matrix9__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   Sum(x, None, False)
 Subject To
- 83: [[0.0 1.0]
- [2.0 3.0]] @ x == 1.0
+ 83: [[np.float64(0.0) np.float64(1.0)]
+ [np.float64(2.0) np.float64(3.0)]] @ x == 1.0
 Bounds
  x free
 End

--- a/tests/snapshots/all__lp_matrix_quadratic5__0.txt
+++ b/tests/snapshots/all__lp_matrix_quadratic5__0.txt
@@ -1,7 +1,7 @@
 CVXPY
 Minimize
-  quad_over_lin([[2.0 0.0]
- [0.0 2.0]] @ x, 1.0)
+  quad_over_lin([[np.float64(2.0) np.float64(0.0)]
+ [np.float64(0.0) np.float64(2.0)]] @ x, 1.0)
 Subject To
 Bounds
  x free


### PR DESCRIPTION
The Gurobi interface in CVXPY was fixed for NumPy v2 in https://github.com/cvxpy/cvxpy/pull/2484, released in v1.5.3.

It seems the formatting of sparse matrices changed, something to do with the interaction between SciPy and NumPy v2. Not quite sure if this change was intended or not 🤷 