### PR TITLE
Support `hstack` and `vstack` atoms

### DIFF
--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -33,15 +33,15 @@ if TYPE_CHECKING:
     from cvxpy.atoms.affine.binary_operators import DivExpression
     from cvxpy.atoms.affine.binary_operators import MulExpression
     from cvxpy.atoms.affine.binary_operators import multiply
+    from cvxpy.atoms.affine.hstack import Hstack
     from cvxpy.atoms.affine.index import index
     from cvxpy.atoms.affine.index import special_index
     from cvxpy.atoms.affine.promote import Promote
     from cvxpy.atoms.affine.sum import Sum
     from cvxpy.atoms.affine.unary_operators import NegExpression
+    from cvxpy.atoms.affine.vstack import Vstack
     from cvxpy.atoms.elementwise.power import power
     from cvxpy.atoms.quad_over_lin import quad_over_lin
-    from cvxpy.atoms.affine.hstack import Hstack
-    from cvxpy.atoms.affine.vstack import Vstack
     from cvxpy.constraints.nonpos import Inequality
     from cvxpy.constraints.zero import Equality
     from cvxpy.utilities.canonical import Canonical
@@ -312,12 +312,12 @@ class Translater:
         left = self.visit(left)
         right = self.visit(right)
         return left == right
-    
+
     def _stack(self, node: Hstack | Vstack, gp_fn: Callable) -> Any:
         args = node.args
         exprs = [self.visit(arg) for arg in args]
         return gp_fn(exprs)
-    
+
     def visit_Hstack(self, node: Hstack) -> Any:
         return self._stack(node, gp.hstack)
 
@@ -480,6 +480,6 @@ class Translater:
             self.vars[var.id] = translate_variable(var, self.model)
             self.model.update()
         return self.vars[var.id]
-    
+
     def visit_Vstack(self, node: Vstack) -> Any:
         return self._stack(node, gp.vstack)

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -441,7 +441,7 @@ class Translater:
         lin = self.visit(y)
         return quad / lin
 
-    def visit_reshape(self, node: cp.reshape) -> gp.MVar:
+    def visit_reshape(self, node: cp.reshape) -> gp.MVar | npt.NDArray[np.float64]:
         """Reshape a variable or expression.
 
         Only MVars have a reshape method, so anything else will be proxied by an MVar.
@@ -450,6 +450,8 @@ class Translater:
         """
         (x,) = node.args
         target_shape = node.shape
+        if x.is_constant():
+            return x.value.reshape(target_shape)
         expr = self.visit(x)
         if isinstance(expr, gp.Var):
             expr = gp.MVar.fromvar(expr)

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
     from cvxpy.atoms.affine.unary_operators import NegExpression
     from cvxpy.atoms.elementwise.power import power
     from cvxpy.atoms.quad_over_lin import quad_over_lin
+    from cvxpy.atoms.affine.hstack import Hstack
+    from cvxpy.atoms.affine.vstack import Vstack
     from cvxpy.constraints.nonpos import Inequality
     from cvxpy.constraints.zero import Equality
     from cvxpy.utilities.canonical import Canonical
@@ -310,6 +312,14 @@ class Translater:
         left = self.visit(left)
         right = self.visit(right)
         return left == right
+    
+    def _stack(self, node: Hstack | Vstack, gp_fn: Callable) -> Any:
+        args = node.args
+        exprs = [self.visit(arg) for arg in args]
+        return gp_fn(exprs)
+    
+    def visit_Hstack(self, node: Hstack) -> Any:
+        return self._stack(node, gp.hstack)
 
     def visit_index(self, node: index) -> Any:
         return self.visit(node.args[0])[node.key]
@@ -468,3 +478,6 @@ class Translater:
             self.vars[var.id] = translate_variable(var, self.model)
             self.model.update()
         return self.vars[var.id]
+    
+    def visit_Vstack(self, node: Vstack) -> Any:
+        return self._stack(node, gp.vstack)

--- a/tests/snapshots/all__lp_hstack0__0.txt
+++ b/tests/snapshots/all__lp_hstack0__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(x, (1,), F)), None, False)
+Subject To
+ 8: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= -1
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x
+Subject To
+ 8: x >= 1
+Bounds
+ x free
+End

--- a/tests/snapshots/all__lp_hstack10__0.txt
+++ b/tests/snapshots/all__lp_hstack10__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Hstack(x, y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 108: 1.0 <= x
+ 112: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + x[1] + y[0] + reshape_1[0]
+Subject To
+ R0: reshape_1[0] = 1
+ 108[0]: x[0] >= 1
+ 108[1]: x[1] >= 1
+ 112[0]: y[0] >= 1
+Bounds
+ x[0] free
+ x[1] free
+ y[0] free
+ reshape_1[0] free
+End

--- a/tests/snapshots/all__lp_hstack10__0.txt
+++ b/tests/snapshots/all__lp_hstack10__0.txt
@@ -24,9 +24,8 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  x[0] + x[1] + y[0] + reshape_1[0]
+  x[0] + x[1] + y[0] + Constant
 Subject To
- R0: reshape_1[0] = 1
  108[0]: x[0] >= 1
  108[1]: x[1] >= 1
  112[0]: y[0] >= 1
@@ -34,5 +33,5 @@ Bounds
  x[0] free
  x[1] free
  y[0] free
- reshape_1[0] free
+ Constant = 1
 End

--- a/tests/snapshots/all__lp_hstack11__0.txt
+++ b/tests/snapshots/all__lp_hstack11__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2,)) @ x, 3.0 @ y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 123: 1.0 <= x
+ 127: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 2 C1 + 3 C2
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0] + 2 x[1] + 3 y[0] + reshape_1[0]
+Subject To
+ R0: reshape_1[0] = 1
+ 123[0]: x[0] >= 1
+ 123[1]: x[1] >= 1
+ 127[0]: y[0] >= 1
+Bounds
+ x[0] free
+ x[1] free
+ y[0] free
+ reshape_1[0] free
+End

--- a/tests/snapshots/all__lp_hstack11__0.txt
+++ b/tests/snapshots/all__lp_hstack11__0.txt
@@ -24,9 +24,8 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  2 x[0] + 2 x[1] + 3 y[0] + reshape_1[0]
+  2 x[0] + 2 x[1] + 3 y[0] + Constant
 Subject To
- R0: reshape_1[0] = 1
  123[0]: x[0] >= 1
  123[1]: x[1] >= 1
  127[0]: y[0] >= 1
@@ -34,5 +33,5 @@ Bounds
  x[0] free
  x[1] free
  y[0] free
- reshape_1[0] free
+ Constant = 1
 End

--- a/tests/snapshots/all__lp_hstack12__0.txt
+++ b/tests/snapshots/all__lp_hstack12__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Hstack(x), None, False)
+Subject To
+ 136: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0,0] + x[0,1] + x[1,0] + x[1,1]
+Subject To
+ 136[0,0]: x[0,0] >= 1
+ 136[0,1]: x[0,1] >= 1
+ 136[1,0]: x[1,0] >= 1
+ 136[1,1]: x[1,1] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+End

--- a/tests/snapshots/all__lp_hstack13__0.txt
+++ b/tests/snapshots/all__lp_hstack13__0.txt
@@ -1,0 +1,50 @@
+CVXPY
+Minimize
+  Sum(Hstack(x, y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 143: 1.0 <= x
+ 148: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3 + C4 + C5
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+ R4: - C4 <= -1
+ R5: - C5 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0,0] + x[0,1] + x[1,0] + x[1,1] + y[0,0] + y[1,0] + 6 Constant
+Subject To
+ 143[0,0]: x[0,0] >= 1
+ 143[0,1]: x[0,1] >= 1
+ 143[1,0]: x[1,0] >= 1
+ 143[1,1]: x[1,1] >= 1
+ 148[0,0]: y[0,0] >= 1
+ 148[1,0]: y[1,0] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+ y[0,0] free
+ y[1,0] free
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_hstack14__0.txt
+++ b/tests/snapshots/all__lp_hstack14__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2, 2)) @ x), None, False)
+Subject To
+ 157: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 2 C1 + 2 C2 + 2 C3
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0,0] + 2 x[0,1] + 2 x[1,0] + 2 x[1,1]
+Subject To
+ 157[0,0]: x[0,0] >= 1
+ 157[0,1]: x[0,1] >= 1
+ 157[1,0]: x[1,0] >= 1
+ 157[1,1]: x[1,1] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+End

--- a/tests/snapshots/all__lp_hstack15__0.txt
+++ b/tests/snapshots/all__lp_hstack15__0.txt
@@ -1,0 +1,51 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2, 2)) @ x, Promote(3.0, (2, 1)) @ y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 168: 1.0 <= x
+ 173: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 2 C1 + 2 C2 + 2 C3 + 3 C4 + 3 C5
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+ R4: - C4 <= -1
+ R5: - C5 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0,0] + 2 x[0,1] + 2 x[1,0] + 2 x[1,1] + 3 y[0,0] + 3 y[1,0]
+   + 6 Constant
+Subject To
+ 168[0,0]: x[0,0] >= 1
+ 168[0,1]: x[0,1] >= 1
+ 168[1,0]: x[1,0] >= 1
+ 168[1,1]: x[1,1] >= 1
+ 173[0,0]: y[0,0] >= 1
+ 173[1,0]: y[1,0] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+ y[0,0] free
+ y[1,0] free
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_hstack1__0.txt
+++ b/tests/snapshots/all__lp_hstack1__0.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(x, (1,), F), reshape(y, (1,), F), reshape(1.0, (1,), F)), None, False)
+Subject To
+ 17: 1.0 <= x
+ 21: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x + y + reshape_1[0]
+Subject To
+ R0: reshape_1[0] = 1
+ 17: x >= 1
+ 21: y >= 1
+Bounds
+ x free
+ y free
+ reshape_1[0] free
+End

--- a/tests/snapshots/all__lp_hstack1__0.txt
+++ b/tests/snapshots/all__lp_hstack1__0.txt
@@ -22,13 +22,12 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  x + y + reshape_1[0]
+  x + y + Constant
 Subject To
- R0: reshape_1[0] = 1
  17: x >= 1
  21: y >= 1
 Bounds
  x free
  y free
- reshape_1[0] free
+ Constant = 1
 End

--- a/tests/snapshots/all__lp_hstack2__0.txt
+++ b/tests/snapshots/all__lp_hstack2__0.txt
@@ -1,0 +1,28 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(2.0 @ x, (1,), F)), None, False)
+Subject To
+ 29: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0
+Subject To
+ R0: - C0 <= -1
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  reshape_1[0]
+Subject To
+ R0: - 2 x + reshape_1[0] = 0
+ 29: x >= 1
+Bounds
+ x free
+ reshape_1[0] free
+End

--- a/tests/snapshots/all__lp_hstack3__0.txt
+++ b/tests/snapshots/all__lp_hstack3__0.txt
@@ -22,11 +22,10 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  reshape_1[0] + reshape_2[0] + reshape_3[0]
+  reshape_1[0] + reshape_2[0] + Constant
 Subject To
  R0: - 2 x + reshape_1[0] = 0
  R1: - 3 y + reshape_2[0] = 0
- R2: reshape_3[0] = 1
  40: x >= 1
  44: y >= 1
 Bounds
@@ -34,5 +33,5 @@ Bounds
  reshape_1[0] free
  y free
  reshape_2[0] free
- reshape_3[0] free
+ Constant = 1
 End

--- a/tests/snapshots/all__lp_hstack3__0.txt
+++ b/tests/snapshots/all__lp_hstack3__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Hstack(reshape(2.0 @ x, (1,), F), reshape(3.0 @ y, (1,), F), reshape(1.0, (1,), F)), None, False)
+Subject To
+ 40: 1.0 <= x
+ 44: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 3 C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  reshape_1[0] + reshape_2[0] + reshape_3[0]
+Subject To
+ R0: - 2 x + reshape_1[0] = 0
+ R1: - 3 y + reshape_2[0] = 0
+ R2: reshape_3[0] = 1
+ 40: x >= 1
+ 44: y >= 1
+Bounds
+ x free
+ reshape_1[0] free
+ y free
+ reshape_2[0] free
+ reshape_3[0] free
+End

--- a/tests/snapshots/all__lp_hstack4__0.txt
+++ b/tests/snapshots/all__lp_hstack4__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Hstack(x), None, False)
+Subject To
+ 52: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= -1
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0]
+Subject To
+ 52[0]: x[0] >= 1
+Bounds
+ x[0] free
+End

--- a/tests/snapshots/all__lp_hstack5__0.txt
+++ b/tests/snapshots/all__lp_hstack5__0.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  Sum(Hstack(x, y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 59: 1.0 <= x
+ 63: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + y[0] + reshape_1[0]
+Subject To
+ R0: reshape_1[0] = 1
+ 59[0]: x[0] >= 1
+ 63[0]: y[0] >= 1
+Bounds
+ x[0] free
+ y[0] free
+ reshape_1[0] free
+End

--- a/tests/snapshots/all__lp_hstack5__0.txt
+++ b/tests/snapshots/all__lp_hstack5__0.txt
@@ -22,13 +22,12 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  x[0] + y[0] + reshape_1[0]
+  x[0] + y[0] + Constant
 Subject To
- R0: reshape_1[0] = 1
  59[0]: x[0] >= 1
  63[0]: y[0] >= 1
 Bounds
  x[0] free
  y[0] free
- reshape_1[0] free
+ Constant = 1
 End

--- a/tests/snapshots/all__lp_hstack6__0.txt
+++ b/tests/snapshots/all__lp_hstack6__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Hstack(2.0 @ x), None, False)
+Subject To
+ 70: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0
+Subject To
+ R0: - C0 <= -1
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0]
+Subject To
+ 70[0]: x[0] >= 1
+Bounds
+ x[0] free
+End

--- a/tests/snapshots/all__lp_hstack7__0.txt
+++ b/tests/snapshots/all__lp_hstack7__0.txt
@@ -22,13 +22,12 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  2 x[0] + 3 y[0] + reshape_1[0]
+  2 x[0] + 3 y[0] + Constant
 Subject To
- R0: reshape_1[0] = 1
  79[0]: x[0] >= 1
  83[0]: y[0] >= 1
 Bounds
  x[0] free
  y[0] free
- reshape_1[0] free
+ Constant = 1
 End

--- a/tests/snapshots/all__lp_hstack7__0.txt
+++ b/tests/snapshots/all__lp_hstack7__0.txt
@@ -1,0 +1,34 @@
+CVXPY
+Minimize
+  Sum(Hstack(2.0 @ x, 3.0 @ y, reshape(1.0, (1,), F)), None, False)
+Subject To
+ 79: 1.0 <= x
+ 83: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 3 C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0] + 3 y[0] + reshape_1[0]
+Subject To
+ R0: reshape_1[0] = 1
+ 79[0]: x[0] >= 1
+ 83[0]: y[0] >= 1
+Bounds
+ x[0] free
+ y[0] free
+ reshape_1[0] free
+End

--- a/tests/snapshots/all__lp_hstack8__0.txt
+++ b/tests/snapshots/all__lp_hstack8__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Hstack(x), None, False)
+Subject To
+ 91: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + x[1]
+Subject To
+ 91[0]: x[0] >= 1
+ 91[1]: x[1] >= 1
+Bounds
+ x[0] free
+ x[1] free
+End

--- a/tests/snapshots/all__lp_hstack9__0.txt
+++ b/tests/snapshots/all__lp_hstack9__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Hstack(Promote(2.0, (2,)) @ x), None, False)
+Subject To
+ 100: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 2 C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0] + 2 x[1]
+Subject To
+ 100[0]: x[0] >= 1
+ 100[1]: x[1] >= 1
+Bounds
+ x[0] free
+ x[1] free
+End

--- a/tests/snapshots/all__lp_reshape28__0.txt
+++ b/tests/snapshots/all__lp_reshape28__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Maximize
   Sum(x, None, False)
 Subject To
- 166: reshape(x, (2, 2), F) <= reshape([1. 1. 1. 1.], (2, 2), F)
+ 172: reshape(x, (4,), F) <= [0. 1. 2. 3.]
 Bounds
  x free
 End
@@ -11,10 +11,10 @@ AFTER COMPILATION
 Minimize
   - C0 - C1 - C2 - C3
 Subject To
- R0: C0 <= 1
+ R0: C0 <= 0
  R1: C1 <= 1
- R2: C2 <= 1
- R3: C3 <= 1
+ R2: C2 <= 2
+ R3: C3 <= 3
 Bounds
  C0 free
  C1 free
@@ -26,10 +26,10 @@ GUROBI
 Maximize
   x[0] + x[1] + x[2] + x[3]
 Subject To
- 166[0,0]: x[0] <= 1
- 166[0,1]: x[1] <= 1
- 166[1,0]: x[2] <= 1
- 166[1,1]: x[3] <= 1
+ 172[0]: x[0] <= 0
+ 172[1]: x[1] <= 1
+ 172[2]: x[2] <= 2
+ 172[3]: x[3] <= 3
 Bounds
  x[0] free
  x[1] free

--- a/tests/snapshots/all__lp_vstack0__0.txt
+++ b/tests/snapshots/all__lp_vstack0__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Vstack(x), None, False)
+Subject To
+ 7: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= -1
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0]
+Subject To
+ 7[0]: x[0] >= 1
+Bounds
+ x[0] free
+End

--- a/tests/snapshots/all__lp_vstack1__0.txt
+++ b/tests/snapshots/all__lp_vstack1__0.txt
@@ -1,0 +1,33 @@
+CVXPY
+Minimize
+  Sum(Vstack(x, y, 1.0), None, False)
+Subject To
+ 13: 1.0 <= x
+ 17: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + y[0] + Constant
+Subject To
+ 13[0]: x[0] >= 1
+ 17[0]: y[0] >= 1
+Bounds
+ x[0] free
+ y[0] free
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_vstack2__0.txt
+++ b/tests/snapshots/all__lp_vstack2__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  Sum(Vstack(2.0 @ x), None, False)
+Subject To
+ 24: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0
+Subject To
+ R0: - C0 <= -1
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0]
+Subject To
+ 24[0]: x[0] >= 1
+Bounds
+ x[0] free
+End

--- a/tests/snapshots/all__lp_vstack3__0.txt
+++ b/tests/snapshots/all__lp_vstack3__0.txt
@@ -1,0 +1,33 @@
+CVXPY
+Minimize
+  Sum(Vstack(2.0 @ x, 3.0 @ y, 1.0), None, False)
+Subject To
+ 32: 1.0 <= x
+ 36: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 3 C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0] + 3 y[0] + Constant
+Subject To
+ 32[0]: x[0] >= 1
+ 36[0]: y[0] >= 1
+Bounds
+ x[0] free
+ y[0] free
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_vstack4__0.txt
+++ b/tests/snapshots/all__lp_vstack4__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Vstack(x), None, False)
+Subject To
+ 44: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + x[1]
+Subject To
+ 44[0]: x[0] >= 1
+ 44[1]: x[1] >= 1
+Bounds
+ x[0] free
+ x[1] free
+End

--- a/tests/snapshots/all__lp_vstack5__0.txt
+++ b/tests/snapshots/all__lp_vstack5__0.txt
@@ -1,0 +1,30 @@
+CVXPY
+Minimize
+  Sum(Vstack(Promote(2.0, (2,)) @ x), None, False)
+Subject To
+ 53: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 2 C1
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0] + 2 x[1]
+Subject To
+ 53[0]: x[0] >= 1
+ 53[1]: x[1] >= 1
+Bounds
+ x[0] free
+ x[1] free
+End

--- a/tests/snapshots/all__lp_vstack6__0.txt
+++ b/tests/snapshots/all__lp_vstack6__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Vstack(x), None, False)
+Subject To
+ 62: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0,0] + x[0,1] + x[1,0] + x[1,1]
+Subject To
+ 62[0,0]: x[0,0] >= 1
+ 62[0,1]: x[0,1] >= 1
+ 62[1,0]: x[1,0] >= 1
+ 62[1,1]: x[1,1] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+End

--- a/tests/snapshots/all__lp_vstack7__0.txt
+++ b/tests/snapshots/all__lp_vstack7__0.txt
@@ -1,0 +1,50 @@
+CVXPY
+Minimize
+  Sum(Vstack(x, y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 69: 1.0 <= x
+ 74: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + C1 + C2 + C3 + C4 + C5
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+ R4: - C4 <= -1
+ R5: - C5 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0,0] + x[0,1] + x[1,0] + x[1,1] + y[0,0] + y[0,1] + 6 Constant
+Subject To
+ 69[0,0]: x[0,0] >= 1
+ 69[0,1]: x[0,1] >= 1
+ 69[1,0]: x[1,0] >= 1
+ 69[1,1]: x[1,1] >= 1
+ 74[0,0]: y[0,0] >= 1
+ 74[0,1]: y[0,1] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+ y[0,0] free
+ y[0,1] free
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_vstack8__0.txt
+++ b/tests/snapshots/all__lp_vstack8__0.txt
@@ -1,0 +1,38 @@
+CVXPY
+Minimize
+  Sum(Vstack(Promote(2.0, (2, 2)) @ x), None, False)
+Subject To
+ 83: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 2 C1 + 2 C2 + 2 C3
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0,0] + 2 x[0,1] + 2 x[1,0] + 2 x[1,1]
+Subject To
+ 83[0,0]: x[0,0] >= 1
+ 83[0,1]: x[0,1] >= 1
+ 83[1,0]: x[1,0] >= 1
+ 83[1,1]: x[1,1] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+End

--- a/tests/snapshots/all__lp_vstack9__0.txt
+++ b/tests/snapshots/all__lp_vstack9__0.txt
@@ -1,0 +1,51 @@
+CVXPY
+Minimize
+  Sum(Vstack(Promote(2.0, (2, 2)) @ x, Promote(3.0, (1, 2)) @ y, [[0.00 1.00]
+ [2.00 3.00]]), None, False)
+Subject To
+ 94: 1.0 <= x
+ 99: 1.0 <= y
+Bounds
+ x free
+ y free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  2 C0 + 2 C1 + 2 C2 + 2 C3 + 3 C4 + 3 C5
+Subject To
+ R0: - C0 <= -1
+ R1: - C1 <= -1
+ R2: - C2 <= -1
+ R3: - C3 <= -1
+ R4: - C4 <= -1
+ R5: - C5 <= -1
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  2 x[0,0] + 2 x[0,1] + 2 x[1,0] + 2 x[1,1] + 3 y[0,0] + 3 y[0,1]
+   + 6 Constant
+Subject To
+ 94[0,0]: x[0,0] >= 1
+ 94[0,1]: x[0,1] >= 1
+ 94[1,0]: x[1,0] >= 1
+ 94[1,1]: x[1,1] >= 1
+ 99[0,0]: y[0,0] >= 1
+ 99[0,1]: y[0,1] >= 1
+Bounds
+ x[0,0] free
+ x[0,1] free
+ x[1,0] free
+ x[1,1] free
+ y[0,0] free
+ y[0,1] free
+ Constant = 1
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -473,7 +473,8 @@ def reshape() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.vec(x) <= np.arange(2)])
 
     x = cp.Variable(4, name="x")
-    a = x + np.ones(4)
+    c = np.ones(4)
+    a = x + c
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (4,)) <= np.ones(4)])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (4, 1)) <= np.ones((4, 1))])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (2, 2)) <= np.ones((2, 2))])
@@ -482,6 +483,7 @@ def reshape() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (4, 1)) <= np.ones((4, 1))])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (2, 2)) <= np.ones((2, 2))])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (1, 4)) <= np.ones((1, 4))])
+    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (2,2)) <= cp.reshape(c, (2,2))])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.vec(x) <= np.arange(4)])
 
 
@@ -562,3 +564,7 @@ def reset_id_counter() -> None:
     from cvxpy.lin_ops.lin_utils import ID_COUNTER
 
     ID_COUNTER.count = 1
+
+
+if __name__ == "__main__":
+    list(all_problems())

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import partial
 from functools import wraps
-from typing import Callable, Literal
+from typing import Callable
 from typing import Iterator
+from typing import Literal
 
 import cvxpy as cp
 import numpy as np
@@ -483,52 +484,64 @@ def reshape() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (4, 1)) <= np.ones((4, 1))])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (2, 2)) <= np.ones((2, 2))])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (1, 4)) <= np.ones((1, 4))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (2,2)) <= cp.reshape(c, (2,2))])
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (2, 2)) <= cp.reshape(c, (2, 2))]
+    )
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.vec(x) <= np.arange(4)])
 
 
 def _stack(stack_name: Literal["vstack", "hstack"]) -> Iterator[cp.Problem]:
     stack = getattr(cp, stack_name)
-    
+
     if stack_name == "hstack":
         # vstack does not support scalar variables
         x = cp.Variable(name="x")
         y = cp.Variable(name="y")
         yield cp.Problem(cp.Minimize(cp.sum(stack([x]))), [x >= 1])
         yield cp.Problem(cp.Minimize(cp.sum(stack([x, y, 1]))), [x >= 1, y >= 1])
-        yield cp.Problem(cp.Minimize(cp.sum(stack([2*x]))), [x >= 1])
-        yield cp.Problem(cp.Minimize(cp.sum(stack([2*x, 3*y, 1]))), [x >= 1, y>= 1])
+        yield cp.Problem(cp.Minimize(cp.sum(stack([2 * x]))), [x >= 1])
+        yield cp.Problem(
+            cp.Minimize(cp.sum(stack([2 * x, 3 * y, 1]))), [x >= 1, y >= 1]
+        )
 
     x = cp.Variable(1, name="x")
     y = cp.Variable(1, name="y")
     yield cp.Problem(cp.Minimize(cp.sum(stack([x]))), [x >= 1])
     yield cp.Problem(cp.Minimize(cp.sum(stack([x, y, 1]))), [x >= 1, y >= 1])
-    yield cp.Problem(cp.Minimize(cp.sum(stack([2*x]))), [x >= 1])
-    yield cp.Problem(cp.Minimize(cp.sum(stack([2*x, 3*y, 1]))), [x >= 1, y>= 1])
+    yield cp.Problem(cp.Minimize(cp.sum(stack([2 * x]))), [x >= 1])
+    yield cp.Problem(cp.Minimize(cp.sum(stack([2 * x, 3 * y, 1]))), [x >= 1, y >= 1])
 
     x = cp.Variable(2, name="x")
     yield cp.Problem(cp.Minimize(cp.sum(stack([x]))), [x >= 1])
-    yield cp.Problem(cp.Minimize(cp.sum(stack([2*x]))), [x >= 1])
+    yield cp.Problem(cp.Minimize(cp.sum(stack([2 * x]))), [x >= 1])
     if stack_name == "hstack":
         yield cp.Problem(cp.Minimize(cp.sum(stack([x, y, 1]))), [x >= 1, y >= 1])
-        yield cp.Problem(cp.Minimize(cp.sum(stack([2*x, 3*y, 1]))), [x >= 1, y>= 1])
+        yield cp.Problem(
+            cp.Minimize(cp.sum(stack([2 * x, 3 * y, 1]))), [x >= 1, y >= 1]
+        )
 
     x = cp.Variable((2, 2), name="x")
-    y = cp.Variable((1, 2), name="y") if stack_name == "vstack" else cp.Variable((2, 1), name="y")
+    y = (
+        cp.Variable((1, 2), name="y")
+        if stack_name == "vstack"
+        else cp.Variable((2, 1), name="y")
+    )
     A = np.arange(4).reshape((2, 2))
     yield cp.Problem(cp.Minimize(cp.sum(stack([x]))), [x >= 1])
     yield cp.Problem(cp.Minimize(cp.sum(stack([x, y, A]))), [x >= 1, y >= 1])
-    yield cp.Problem(cp.Minimize(cp.sum(stack([2*x]))), [x >= 1])
-    yield cp.Problem(cp.Minimize(cp.sum(stack([2*x, 3*y, A]))), [x >= 1, y>= 1])
+    yield cp.Problem(cp.Minimize(cp.sum(stack([2 * x]))), [x >= 1])
+    yield cp.Problem(cp.Minimize(cp.sum(stack([2 * x, 3 * y, A]))), [x >= 1, y >= 1])
 
 
 @group_cases("vstack")
 def vstack() -> Iterator[cp.Problem]:
     yield from _stack("vstack")
 
+
 @group_cases("hstack")
 def hstack() -> Iterator[cp.Problem]:
     yield from _stack("hstack")
+
 
 @group_cases("attributes")
 def attributes() -> Iterator[cp.Problem]:


### PR DESCRIPTION
Mostly a wrapper around a series of reshapes, as the stacking itself is then handled by Gurobi.

The tests have some differences between H- and V-stack because both aren't implemented in the same way. `cp.hstack` will reshape scalars into (1,)-shaped expressions, but `cp.vstack` does not so it can't be called with scalars.

Resolves #32 