### PR TITLE
Stack is not available on `gurobipy<11`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,10 @@ build.hooks.vcs.version-file = "src/cvxpy_gurobi/_version.py"
 dependencies = [
   "cvxpy-base==1.5.*",
   "gurobipy==11.*",
-  "numpy!=2.1.0",  # broken with cvxpy<=1.5.3
+  "numpy",
   "pytest",
   "pytest-insta",
+  "pytest-xdist",
 ]
 [tool.hatch.envs.default.scripts]
 update-snapshots = "pytest --insta update {args:tests}"
@@ -69,31 +70,33 @@ versions = [
 ]
 
 [tool.hatch.envs.hatch-test]
-dependencies = [
+extra-dependencies = [
   "cvxpy-base=={matrix:cvxpy}.*",
   "gurobipy=={matrix:gurobipy}.*",
-  "numpy!=2.1.0",  # broken with cvxpy<=1.5.3
+  "numpy",
   "scipy{matrix:scipy:}",
-  "coverage[toml]",
-  "pytest",
   "pytest-insta",
-  "pytest-xdist",
 ]
 matrix-name-format = "{variable}{value}"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.12"]
-gurobipy = ["11"]
-cvxpy = ["1.5", "1.4"]
-
-[[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.11"]
-gurobipy = ["11"]
+python = ["3.8"]
+gurobipy = ["10"]
 cvxpy = ["1.3"]
+numpy = ["<2"]
 scipy = ["<1.14"]  # cvxpy 1.3 uses scipy features (.A) removed in 1.14
 
+# TODO: this env seems broken, errors with:
+#     import _cvxcore
+#     AttributeError: _ARRAY_API not found
+# [[tool.hatch.envs.hatch-test.matrix]]
+# python = ["3.9"]
+# gurobipy = ["11"]
+# cvxpy = ["1.4"]
+# numpy = ["<2"]
+
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.9", "3.8"]
+python = ["3.10", "3.11", "3.12"]
 gurobipy = ["11"]
 cvxpy = ["1.5"]
 

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import partial
 from functools import wraps
-from typing import Callable, Generator
+from typing import Callable
+from typing import Generator
 from typing import Iterator
 from typing import Literal
 
@@ -11,7 +12,8 @@ import cvxpy as cp
 import numpy as np
 import scipy.sparse as sp
 
-from cvxpy_gurobi.translation import CVXPY_VERSION, GUROBIPY_VERSION
+from cvxpy_gurobi.translation import CVXPY_VERSION
+from cvxpy_gurobi.translation import GUROBIPY_VERSION
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This PR updates the test matrix to get all tests passing. Noticeable changes:
- `gp.{h,v}stack` was added in version 11, so skip the corresponding tests and raise an error during translation,
- older versions' tests are run first as they are the most likely to have failures,
- removed some version restrictions on numpy since the issues were fixed in recent versions,
- `pytest-xdist` is now installed in test environments, the number of tests grew large enough that the time spent instantiating workers is smaller than the gain due to parallelization.

There is a weird issue with `cvxpy==1.4`, not sure what it's about yet, so it's not tested.