### PR TITLE
Fix handling of sum of scalar expression

### DIFF
--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -89,6 +89,10 @@ def _is_scalar_shape(shape: tuple[int, ...]) -> bool:
     return prod(shape) == 1
 
 
+def _is_scalar(expr: Any) -> bool:
+    return _is_scalar_shape(_shape(expr))
+
+
 def _squeeze_shape(shape: tuple[int, ...]) -> tuple[int, ...]:
     return tuple(d for d in shape if d != 1)
 
@@ -479,7 +483,7 @@ class Translater:
 
     def visit_Sum(self, node: Sum) -> Any:
         expr = self.visit(node.args[0])
-        if _is_scalar_shape(_shape(expr)):
+        if _is_scalar(expr):
             return expr
         return expr.sum(axis=node.axis)
 

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -479,6 +479,8 @@ class Translater:
 
     def visit_Sum(self, node: Sum) -> Any:
         expr = self.visit(node.args[0])
+        if _is_scalar_shape(_shape(expr)):
+            return expr
         return expr.sum(axis=node.axis)
 
     def visit_Variable(self, var: cp.Variable) -> AnyVar:

--- a/tests/snapshots/all__lp_sum_scalar0__0.txt
+++ b/tests/snapshots/all__lp_sum_scalar0__0.txt
@@ -1,0 +1,23 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_sum_scalar1__0.txt
+++ b/tests/snapshots/all__lp_sum_scalar1__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Minimize
+  Sum(x + 1.0, None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x + Constant
+Subject To
+Bounds
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_sum_scalar2__0.txt
+++ b/tests/snapshots/all__lp_sum_scalar2__0.txt
@@ -1,0 +1,23 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_sum_scalar3__0.txt
+++ b/tests/snapshots/all__lp_sum_scalar3__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Minimize
+  Sum(x + 1.0, None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + Constant
+Subject To
+Bounds
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_sum_scalar4__0.txt
+++ b/tests/snapshots/all__lp_sum_scalar4__0.txt
@@ -1,0 +1,23 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0,0]
+Subject To
+Bounds
+End

--- a/tests/snapshots/all__lp_sum_scalar5__0.txt
+++ b/tests/snapshots/all__lp_sum_scalar5__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Minimize
+  Sum(x + 1.0, None, False)
+Subject To
+Bounds
+ 0.0 <= x
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0
+Subject To
+ R0: - C0 <= 0
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  x[0,0] + Constant
+Subject To
+Bounds
+ Constant = 1
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -449,15 +449,15 @@ def indexing() -> Iterator[cp.Problem]:
 def sum_scalar() -> Iterator[cp.Problem]:
     x = cp.Variable(name="x", nonneg=True)
     yield cp.Problem(cp.Minimize(cp.sum(x)))
-    yield cp.Problem(cp.Minimize(cp.sum(x+1)))
+    yield cp.Problem(cp.Minimize(cp.sum(x + 1)))
 
     x = cp.Variable(1, name="x", nonneg=True)
     yield cp.Problem(cp.Minimize(cp.sum(x)))
-    yield cp.Problem(cp.Minimize(cp.sum(x+1)))
+    yield cp.Problem(cp.Minimize(cp.sum(x + 1)))
 
     x = cp.Variable((1, 1), name="x", nonneg=True)
     yield cp.Problem(cp.Minimize(cp.sum(x)))
-    yield cp.Problem(cp.Minimize(cp.sum(x+1)))
+    yield cp.Problem(cp.Minimize(cp.sum(x + 1)))
 
 
 @group_cases("sum_axis")

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -56,6 +56,7 @@ def all_problems() -> Generator[ProblemTestCase, None, None]:
         genexpr_norm2,
         genexpr_norminf,
         indexing,
+        sum_scalar,
         sum_axis,
         reshape,
         hstack if GUROBIPY_VERSION >= (11,) else lambda: iter(()),
@@ -442,6 +443,21 @@ def indexing() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(x[:])))
     yield cp.Problem(cp.Minimize(cp.sum(y[:])))
     yield cp.Problem(cp.Minimize(cp.sum(m[:, :])))
+
+
+@group_cases("sum_scalar")
+def sum_scalar() -> Iterator[cp.Problem]:
+    x = cp.Variable(name="x", nonneg=True)
+    yield cp.Problem(cp.Minimize(cp.sum(x)))
+    yield cp.Problem(cp.Minimize(cp.sum(x+1)))
+
+    x = cp.Variable(1, name="x", nonneg=True)
+    yield cp.Problem(cp.Minimize(cp.sum(x)))
+    yield cp.Problem(cp.Minimize(cp.sum(x+1)))
+
+    x = cp.Variable((1, 1), name="x", nonneg=True)
+    yield cp.Problem(cp.Minimize(cp.sum(x)))
+    yield cp.Problem(cp.Minimize(cp.sum(x+1)))
 
 
 @group_cases("sum_axis")


### PR DESCRIPTION
`cvxpy` does not need special handling for `cp.sum(x)` where `x` is a scalar expression, but once translated into `gurobipy` objects, scalar expressions do not have the `.sum` method that matrixapi objects have. So in the scalar case, we simply return the expression to sum.