### PR TITLE
Ensure `minimum`/`maximum` arguments are scalars

### DIFF
--- a/tests/snapshots/all__lp_genexpr_min_max11__0.txt
+++ b/tests/snapshots/all__lp_genexpr_min_max11__0.txt
@@ -24,13 +24,11 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  AddExpression_1
+  x[0] + y
 Subject To
- R0: - x[0] - y + AddExpression_1 = 0
  95[0]: x[0] <= 1
  99: y <= 1
 Bounds
  x[0] free
  y free
- AddExpression_1 free
 End

--- a/tests/snapshots/all__lp_genexpr_min_max15__0.txt
+++ b/tests/snapshots/all__lp_genexpr_min_max15__0.txt
@@ -24,13 +24,11 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  AddExpression_1
+  x[0] + y
 Subject To
- R0: - x[0] - y + AddExpression_1 = 0
  127[0]: x[0] >= 1
  131: y >= 1
 Bounds
  x[0] free
  y free
- AddExpression_1 free
 End

--- a/tests/snapshots/all__lp_genexpr_min_max3__0.txt
+++ b/tests/snapshots/all__lp_genexpr_min_max3__0.txt
@@ -24,13 +24,11 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  AddExpression_1
+  x + y
 Subject To
- R0: - x - y + AddExpression_1 = 0
  29: x <= 1
  33: y <= 1
 Bounds
  x free
  y free
- AddExpression_1 free
 End

--- a/tests/snapshots/all__lp_genexpr_min_max7__0.txt
+++ b/tests/snapshots/all__lp_genexpr_min_max7__0.txt
@@ -24,13 +24,11 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  AddExpression_1
+  x + y
 Subject To
- R0: - x - y + AddExpression_1 = 0
  61: x >= 1
  65: y >= 1
 Bounds
  x free
  y free
- AddExpression_1 free
 End


### PR DESCRIPTION
Fixes #47 by forcing the `gp.min` and `gp.max` arguments to be scalars. I added a new parameter to `translate_into_variable` to explicitly ask for a scalar variable. Before this change, we tried to create a scalar variable when possible, but now it's explicit.

Now the responsabilities of `translate_into_variable` and `translate_into_scalar` are a little mixed, so it might be worth revisiting/merging them in the future.

The snapshot differences come from the change in the `_min_max` function to not create an auxilliary variable if the argument is already scalar. It makes a nicer looking problem, but we lose track of the `min`/`max` completely, so I'm still not 100% sure it should stay this way.