### PR TITLE
Fix `minimum`/`maximum` with a scalar argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ extra-dependencies = [
 [tool.hatch.envs.snapshots]
 description = "The environment used to generate the snapshot LP files"
 template = "latest"
-scripts = { update = "pytest --insta update {args:tests}" }
+scripts = { update = "pytest --insta update {args} tests/test_all.py::test_lp" }
 
 [tool.hatch.envs.oldest]
 description = "The oldest supported set of dependencies, for testing purposes"

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -101,7 +101,16 @@ def iterzip_subexpressions(
     *exprs: Any, shape: tuple[int, ...]
 ) -> Iterator[tuple[Any, ...]]:
     for idx in np.ndindex(shape):
-        yield tuple(expr[idx] for expr in exprs)
+        idx_exprs = []
+        for expr in exprs:
+            if _shape(expr) == ():
+                idx_exprs.append(expr)
+            elif _is_scalar(expr):
+                item = expr[*(0,)*len(_shape(expr))]
+                idx_exprs.append(item)
+            else:
+                idx_exprs.append(expr[idx])
+        yield tuple(idx_exprs)
 
 
 def iter_subexpressions(expr: Any, shape: tuple[int, ...]) -> Iterator[Any]:

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -106,7 +106,7 @@ def iterzip_subexpressions(
             if _shape(expr) == ():
                 idx_exprs.append(expr)
             elif _is_scalar(expr):
-                item = expr[*(0,)*len(_shape(expr))]
+                item = expr[(0,) * len(idx)]
                 idx_exprs.append(item)
             else:
                 idx_exprs.append(expr[idx])

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum18__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum18__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(X, None, False)
 Subject To
- 8: -1.0 <= minimum(X, [ 2. -1.])
+ 9: -1.0 <= minimum(X, [ 2. -1.])
 Bounds
  X free
 End
@@ -28,8 +28,8 @@ GUROBI
 Minimize
   X[0] + X[1]
 Subject To
- 8[0]: minimum_1 >= -1
- 8[1]: minimum_2 >= -1
+ 9[0]: minimum_1 >= -1
+ 9[1]: minimum_2 >= -1
 Bounds
  X[0] free
  X[1] free

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum19__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum19__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(X + Y, None, False)
 Subject To
- 16: 1.0 <= minimum(X, Y)
+ 17: 1.0 <= minimum(X, Y)
 Bounds
  X free
  Y free
@@ -31,8 +31,8 @@ GUROBI
 Minimize
   X[0] + X[1] + Y[0] + Y[1]
 Subject To
- 16[0]: minimum_1 >= 1
- 16[1]: minimum_2 >= 1
+ 17[0]: minimum_1 >= 1
+ 17[1]: minimum_2 >= 1
 Bounds
  X[0] free
  X[1] free

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum20__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum20__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(X + Y, None, False)
 Subject To
- 23: [ 2. -1.] <= minimum(X, Y)
+ 24: [ 2. -1.] <= minimum(X, Y)
 Bounds
  X free
  Y free
@@ -31,8 +31,8 @@ GUROBI
 Minimize
   X[0] + X[1] + Y[0] + Y[1]
 Subject To
- 23[0]: minimum_1 >= 2
- 23[1]: minimum_2 >= -1
+ 24[0]: minimum_1 >= 2
+ 24[1]: minimum_2 >= -1
 Bounds
  X[0] free
  X[1] free

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum21__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum21__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(X + Y, None, False)
 Subject To
- 31: -1.0 <= minimum(X, Y, [ 2. -1.])
+ 32: -1.0 <= minimum(X, Y, [ 2. -1.])
 Bounds
  X free
  Y free
@@ -33,8 +33,8 @@ GUROBI
 Minimize
   X[0] + X[1] + Y[0] + Y[1]
 Subject To
- 31[0]: minimum_1 >= -1
- 31[1]: minimum_2 >= -1
+ 32[0]: minimum_1 >= -1
+ 32[1]: minimum_2 >= -1
 Bounds
  X[0] free
  X[1] free

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum22__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum22__0.txt
@@ -2,8 +2,8 @@ CVXPY
 Minimize
   Sum(X, None, False)
 Subject To
- 38: -Y <= minimum(X, [ 2. -1.])
- 43: Y == 1.0
+ 39: -Y <= minimum(X, [ 2. -1.])
+ 44: Y == 1.0
 Bounds
  X free
  Y free
@@ -34,10 +34,10 @@ GUROBI
 Minimize
   X[0] + X[1]
 Subject To
- 38[0]: - Y[0] - minimum_1 <= 0
- 38[1]: - Y[1] - minimum_2 <= 0
- 43[0]: Y[0] = 1
- 43[1]: Y[1] = 1
+ 39[0]: - Y[0] - minimum_1 <= 0
+ 39[1]: - Y[1] - minimum_2 <= 0
+ 44[0]: Y[0] = 1
+ 44[1]: Y[1] = 1
 Bounds
  X[0] free
  X[1] free

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum23__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum23__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Minimize
   Sum(X, None, False)
 Subject To
- 51: -1.0 <= minimum(X + [ 2. -1.], [ 2. -1.])
+ 52: -1.0 <= minimum(X + [ 2. -1.], [ 2. -1.])
 Bounds
  X free
 End
@@ -30,8 +30,8 @@ Minimize
 Subject To
  R0: - X[0] + index_1 = 2
  R1: - X[1] + index_3 = -1
- 51[0]: minimum_2 >= -1
- 51[1]: minimum_4 >= -1
+ 52[0]: minimum_2 >= -1
+ 52[1]: minimum_4 >= -1
 Bounds
  X[0] free
  X[1] free

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum24__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum24__0.txt
@@ -1,41 +1,49 @@
 CVXPY
-Maximize
+Minimize
   Sum(X, None, False)
 Subject To
- 6: maximum(X, [ 2. -1.]) <= 2.0
+ 59: 0.0 <= minimum(X, z, 1.0)
+ 63: z == 1.0
 Bounds
  X free
+ z free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1
+  C0 + C1
 Subject To
- R0: C0 - C2 <= 0
- R1: C1 - C3 <= 0
- R2: - C2 <= -2
- R3: - C3 <= 1
- R4: C2 <= 2
- R5: C3 <= 2
+ R0: C4 = 1
+ R1: - C0 - C2 <= 0
+ R2: - C1 - C3 <= 0
+ R3: - C2 - C4 <= 0
+ R4: - C3 - C4 <= 0
+ R5: - C2 <= 1
+ R6: - C3 <= 1
+ R7: C2 <= 0
+ R8: C3 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
+ C4 free
 End
 ----------------------------------------
 GUROBI
-Maximize
+Minimize
   X[0] + X[1]
 Subject To
- 6[0]: maximum_1 <= 2
- 6[1]: maximum_2 <= 2
+ 59[0]: minimum_1 >= 0
+ 59[1]: minimum_2 >= 0
+ 63: z = 1
 Bounds
  X[0] free
  X[1] free
- maximum_1 free
- maximum_2 free
+ z free
+ minimum_1 free
+ minimum_2 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0] , 2 )
- GC1: maximum_2 = MAX ( X[1] , -1 )
+ GC0: minimum_1 = MIN ( X[0] , z , 1 )
+ GC1: minimum_2 = MIN ( X[1] , z , 1 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum25__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum25__0.txt
@@ -1,46 +1,41 @@
 CVXPY
 Maximize
-  Sum(X + Y, None, False)
+  Sum(X, None, False)
 Subject To
- 14: maximum(X, Y) <= 1.0
+ 6: maximum(X, [ 2. -1.]) <= 2.0
 Bounds
  X free
- Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1 - C2 - C3
+  - C0 - C1
 Subject To
- R0: C0 - C4 <= 0
- R1: C1 - C5 <= 0
- R2: C2 - C4 <= 0
- R3: C3 - C5 <= 0
- R4: C4 <= 1
- R5: C5 <= 1
+ R0: C0 - C2 <= 0
+ R1: C1 - C3 <= 0
+ R2: - C2 <= -2
+ R3: - C3 <= 1
+ R4: C2 <= 2
+ R5: C3 <= 2
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
 End
 ----------------------------------------
 GUROBI
 Maximize
-  X[0] + X[1] + Y[0] + Y[1]
+  X[0] + X[1]
 Subject To
- 14[0]: maximum_1 <= 1
- 14[1]: maximum_2 <= 1
+ 6[0]: maximum_1 <= 2
+ 6[1]: maximum_2 <= 2
 Bounds
  X[0] free
  X[1] free
- Y[0] free
- Y[1] free
  maximum_1 free
  maximum_2 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0] , Y[0] )
- GC1: maximum_2 = MAX ( X[1] , Y[1] )
+ GC0: maximum_1 = MAX ( X[0] , 2 )
+ GC1: maximum_2 = MAX ( X[1] , -1 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum26__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum26__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Maximize
   Sum(X + Y, None, False)
 Subject To
- 21: maximum(X, Y) <= [ 2. -1.]
+ 14: maximum(X, Y) <= 1.0
 Bounds
  X free
  Y free
@@ -16,8 +16,8 @@ Subject To
  R1: C1 - C5 <= 0
  R2: C2 - C4 <= 0
  R3: C3 - C5 <= 0
- R4: C4 <= 2
- R5: C5 <= -1
+ R4: C4 <= 1
+ R5: C5 <= 1
 Bounds
  C0 free
  C1 free
@@ -31,8 +31,8 @@ GUROBI
 Maximize
   X[0] + X[1] + Y[0] + Y[1]
 Subject To
- 21[0]: maximum_1 <= 2
- 21[1]: maximum_2 <= -1
+ 14[0]: maximum_1 <= 1
+ 14[1]: maximum_2 <= 1
 Bounds
  X[0] free
  X[1] free

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum27__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum27__0.txt
@@ -2,7 +2,7 @@ CVXPY
 Maximize
   Sum(X + Y, None, False)
 Subject To
- 29: maximum(X, Y, [ 2. -1.]) <= 2.0
+ 21: maximum(X, Y) <= [ 2. -1.]
 Bounds
  X free
  Y free
@@ -16,10 +16,8 @@ Subject To
  R1: C1 - C5 <= 0
  R2: C2 - C4 <= 0
  R3: C3 - C5 <= 0
- R4: - C4 <= -2
- R5: - C5 <= 1
- R6: C4 <= 2
- R7: C5 <= 2
+ R4: C4 <= 2
+ R5: C5 <= -1
 Bounds
  C0 free
  C1 free
@@ -33,8 +31,8 @@ GUROBI
 Maximize
   X[0] + X[1] + Y[0] + Y[1]
 Subject To
- 29[0]: maximum_1 <= 2
- 29[1]: maximum_2 <= 2
+ 21[0]: maximum_1 <= 2
+ 21[1]: maximum_2 <= -1
 Bounds
  X[0] free
  X[1] free
@@ -43,6 +41,6 @@ Bounds
  maximum_1 free
  maximum_2 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0] , Y[0] , 2 )
- GC1: maximum_2 = MAX ( X[1] , Y[1] , -1 )
+ GC0: maximum_1 = MAX ( X[0] , Y[0] )
+ GC1: maximum_2 = MAX ( X[1] , Y[1] )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum28__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum28__0.txt
@@ -1,9 +1,8 @@
 CVXPY
 Maximize
-  Sum(X, None, False)
+  Sum(X + Y, None, False)
 Subject To
- 35: maximum(X, [ 2. -1.]) <= Y
- 40: Y == 2.0
+ 29: maximum(X, Y, [ 2. -1.]) <= 2.0
 Bounds
  X free
  Y free
@@ -11,16 +10,16 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1
+  - C0 - C1 - C2 - C3
 Subject To
- R0: C4 = 2
- R1: C5 = 2
- R2: C0 - C2 <= 0
- R3: C1 - C3 <= 0
- R4: - C2 <= -2
- R5: - C3 <= 1
- R6: C2 - C4 <= 0
- R7: C3 - C5 <= 0
+ R0: C0 - C4 <= 0
+ R1: C1 - C5 <= 0
+ R2: C2 - C4 <= 0
+ R3: C3 - C5 <= 0
+ R4: - C4 <= -2
+ R5: - C5 <= 1
+ R6: C4 <= 2
+ R7: C5 <= 2
 Bounds
  C0 free
  C1 free
@@ -32,20 +31,18 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  X[0] + X[1]
+  X[0] + X[1] + Y[0] + Y[1]
 Subject To
- 35[0]: maximum_1 - Y[0] <= 0
- 35[1]: maximum_2 - Y[1] <= 0
- 40[0]: Y[0] = 2
- 40[1]: Y[1] = 2
+ 29[0]: maximum_1 <= 2
+ 29[1]: maximum_2 <= 2
 Bounds
  X[0] free
  X[1] free
- maximum_1 free
- maximum_2 free
  Y[0] free
  Y[1] free
+ maximum_1 free
+ maximum_2 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0] , 2 )
- GC1: maximum_2 = MAX ( X[1] , -1 )
+ GC0: maximum_1 = MAX ( X[0] , Y[0] , 2 )
+ GC1: maximum_2 = MAX ( X[1] , Y[1] , -1 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum29__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum29__0.txt
@@ -2,44 +2,50 @@ CVXPY
 Maximize
   Sum(X, None, False)
 Subject To
- 48: maximum(X + [ 2. -1.], [ 2. -1.]) <= 2.0
+ 35: maximum(X, [ 2. -1.]) <= Y
+ 40: Y == 2.0
 Bounds
  X free
+ Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
   - C0 - C1
 Subject To
- R0: C0 - C2 <= -2
- R1: C1 - C3 <= 1
- R2: - C2 <= -2
- R3: - C3 <= 1
- R4: C2 <= 2
- R5: C3 <= 2
+ R0: C4 = 2
+ R1: C5 = 2
+ R2: C0 - C2 <= 0
+ R3: C1 - C3 <= 0
+ R4: - C2 <= -2
+ R5: - C3 <= 1
+ R6: C2 - C4 <= 0
+ R7: C3 - C5 <= 0
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
+ C4 free
+ C5 free
 End
 ----------------------------------------
 GUROBI
 Maximize
   X[0] + X[1]
 Subject To
- R0: - X[0] + index_1 = 2
- R1: - X[1] + index_3 = -1
- 48[0]: maximum_2 <= 2
- 48[1]: maximum_4 <= 2
+ 35[0]: maximum_1 - Y[0] <= 0
+ 35[1]: maximum_2 - Y[1] <= 0
+ 40[0]: Y[0] = 2
+ 40[1]: Y[1] = 2
 Bounds
  X[0] free
  X[1] free
- index_1 free
+ maximum_1 free
  maximum_2 free
- index_3 free
- maximum_4 free
+ Y[0] free
+ Y[1] free
 General Constraints
- GC0: maximum_2 = MAX ( index_1 , 2 )
- GC1: maximum_4 = MAX ( index_3 , -1 )
+ GC0: maximum_1 = MAX ( X[0] , 2 )
+ GC1: maximum_2 = MAX ( X[1] , -1 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum30__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum30__0.txt
@@ -1,60 +1,45 @@
 CVXPY
-Minimize
+Maximize
   Sum(X, None, False)
 Subject To
- 8: -2.0 <= minimum(X, [[1.00 -2.00]
- [3.00 4.00]])
+ 48: maximum(X + [ 2. -1.], [ 2. -1.]) <= 2.0
 Bounds
  X free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C1 + C2 + C3
+  - C0 - C1
 Subject To
- R0: - C0 - C4 <= 0
- R1: - C1 - C5 <= 0
- R2: - C2 - C6 <= 0
- R3: - C3 - C7 <= 0
- R4: - C4 <= 1
- R5: - C5 <= 3
- R6: - C6 <= -2
- R7: - C7 <= 4
- R8: C4 <= 2
- R9: C5 <= 2
- R10: C6 <= 2
- R11: C7 <= 2
+ R0: C0 - C2 <= -2
+ R1: C1 - C3 <= 1
+ R2: - C2 <= -2
+ R3: - C3 <= 1
+ R4: C2 <= 2
+ R5: C3 <= 2
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
 End
 ----------------------------------------
 GUROBI
-Minimize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+Maximize
+  X[0] + X[1]
 Subject To
- 8[0,0]: minimum_1 >= -2
- 8[0,1]: minimum_2 >= -2
- 8[1,0]: minimum_3 >= -2
- 8[1,1]: minimum_4 >= -2
+ R0: - X[0] + index_1 = 2
+ R1: - X[1] + index_3 = -1
+ 48[0]: maximum_2 <= 2
+ 48[1]: maximum_4 <= 2
 Bounds
- X[0,0] free
- X[0,1] free
- X[1,0] free
- X[1,1] free
- minimum_1 free
- minimum_2 free
- minimum_3 free
- minimum_4 free
+ X[0] free
+ X[1] free
+ index_1 free
+ maximum_2 free
+ index_3 free
+ maximum_4 free
 General Constraints
- GC0: minimum_1 = MIN ( X[0,0] , 1 )
- GC1: minimum_2 = MIN ( X[0,1] , -2 )
- GC2: minimum_3 = MIN ( X[1,0] , 3 )
- GC3: minimum_4 = MIN ( X[1,1] , 4 )
+ GC0: maximum_2 = MAX ( index_1 , 2 )
+ GC1: maximum_4 = MAX ( index_3 , -1 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum31__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum31__0.txt
@@ -1,68 +1,49 @@
 CVXPY
-Minimize
-  Sum(X + Y, None, False)
+Maximize
+  Sum(X, None, False)
 Subject To
- 16: 1.0 <= minimum(X, Y)
+ 55: maximum(X, z, 1.0) <= 2.0
+ 59: z == 1.0
 Bounds
  X free
- Y free
+ z free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C1 + C2 + C3 + C4 + C5 + C6 + C7
+  - C0 - C1
 Subject To
- R0: - C0 - C8 <= 0
- R1: - C1 - C9 <= 0
- R2: - C2 - C10 <= 0
- R3: - C3 - C11 <= 0
- R4: - C4 - C8 <= 0
- R5: - C5 - C9 <= 0
- R6: - C6 - C10 <= 0
- R7: - C7 - C11 <= 0
- R8: C8 <= -1
- R9: C9 <= -1
- R10: C10 <= -1
- R11: C11 <= -1
+ R0: C4 = 1
+ R1: C0 - C2 <= 0
+ R2: C1 - C3 <= 0
+ R3: - C2 + C4 <= 0
+ R4: - C3 + C4 <= 0
+ R5: - C2 <= -1
+ R6: - C3 <= -1
+ R7: C2 <= 2
+ R8: C3 <= 2
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
  C4 free
- C5 free
- C6 free
- C7 free
- C8 free
- C9 free
- C10 free
- C11 free
 End
 ----------------------------------------
 GUROBI
-Minimize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
+Maximize
+  X[0] + X[1]
 Subject To
- 16[0,0]: minimum_1 >= 1
- 16[0,1]: minimum_2 >= 1
- 16[1,0]: minimum_3 >= 1
- 16[1,1]: minimum_4 >= 1
+ 55[0]: maximum_1 <= 2
+ 55[1]: maximum_2 <= 2
+ 59: z = 1
 Bounds
- X[0,0] free
- X[0,1] free
- X[1,0] free
- X[1,1] free
- Y[0,0] free
- Y[0,1] free
- Y[1,0] free
- Y[1,1] free
- minimum_1 free
- minimum_2 free
- minimum_3 free
- minimum_4 free
+ X[0] free
+ X[1] free
+ z free
+ maximum_1 free
+ maximum_2 free
 General Constraints
- GC0: minimum_1 = MIN ( X[0,0] , Y[0,0] )
- GC1: minimum_2 = MIN ( X[0,1] , Y[0,1] )
- GC2: minimum_3 = MIN ( X[1,0] , Y[1,0] )
- GC3: minimum_4 = MIN ( X[1,1] , Y[1,1] )
+ GC0: maximum_1 = MAX ( X[0] , z , 1 )
+ GC1: maximum_2 = MAX ( X[1] , z , 1 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum32__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum32__0.txt
@@ -1,30 +1,29 @@
 CVXPY
 Minimize
-  Sum(X + Y, None, False)
+  Sum(X, None, False)
 Subject To
- 23: [[1.00 -2.00]
- [3.00 4.00]] <= minimum(X, Y)
+ 8: -2.0 <= minimum(X, [[1.00 -2.00]
+ [3.00 4.00]])
 Bounds
  X free
- Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C1 + C2 + C3 + C4 + C5 + C6 + C7
+  C0 + C1 + C2 + C3
 Subject To
- R0: - C0 - C8 <= 0
- R1: - C1 - C9 <= 0
- R2: - C2 - C10 <= 0
- R3: - C3 - C11 <= 0
- R4: - C4 - C8 <= 0
- R5: - C5 - C9 <= 0
- R6: - C6 - C10 <= 0
- R7: - C7 - C11 <= 0
- R8: C8 <= -1
- R9: C9 <= -3
- R10: C10 <= 2
- R11: C11 <= -4
+ R0: - C0 - C4 <= 0
+ R1: - C1 - C5 <= 0
+ R2: - C2 - C6 <= 0
+ R3: - C3 - C7 <= 0
+ R4: - C4 <= 1
+ R5: - C5 <= 3
+ R6: - C6 <= -2
+ R7: - C7 <= 4
+ R8: C4 <= 2
+ R9: C5 <= 2
+ R10: C6 <= 2
+ R11: C7 <= 2
 Bounds
  C0 free
  C1 free
@@ -34,36 +33,28 @@ Bounds
  C5 free
  C6 free
  C7 free
- C8 free
- C9 free
- C10 free
- C11 free
 End
 ----------------------------------------
 GUROBI
 Minimize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
+  X[0,0] + X[0,1] + X[1,0] + X[1,1]
 Subject To
- 23[0,0]: minimum_1 >= 1
- 23[0,1]: minimum_2 >= -2
- 23[1,0]: minimum_3 >= 3
- 23[1,1]: minimum_4 >= 4
+ 8[0,0]: minimum_1 >= -2
+ 8[0,1]: minimum_2 >= -2
+ 8[1,0]: minimum_3 >= -2
+ 8[1,1]: minimum_4 >= -2
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- Y[0,0] free
- Y[0,1] free
- Y[1,0] free
- Y[1,1] free
  minimum_1 free
  minimum_2 free
  minimum_3 free
  minimum_4 free
 General Constraints
- GC0: minimum_1 = MIN ( X[0,0] , Y[0,0] )
- GC1: minimum_2 = MIN ( X[0,1] , Y[0,1] )
- GC2: minimum_3 = MIN ( X[1,0] , Y[1,0] )
- GC3: minimum_4 = MIN ( X[1,1] , Y[1,1] )
+ GC0: minimum_1 = MIN ( X[0,0] , 1 )
+ GC1: minimum_2 = MIN ( X[0,1] , -2 )
+ GC2: minimum_3 = MIN ( X[1,0] , 3 )
+ GC3: minimum_4 = MIN ( X[1,1] , 4 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum33__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum33__0.txt
@@ -2,8 +2,7 @@ CVXPY
 Minimize
   Sum(X + Y, None, False)
 Subject To
- 31: -2.0 <= minimum(X, Y, [[1.00 -2.00]
- [3.00 4.00]])
+ 16: 1.0 <= minimum(X, Y)
 Bounds
  X free
  Y free
@@ -21,14 +20,10 @@ Subject To
  R5: - C5 - C9 <= 0
  R6: - C6 - C10 <= 0
  R7: - C7 - C11 <= 0
- R8: - C8 <= 1
- R9: - C9 <= 3
- R10: - C10 <= -2
- R11: - C11 <= 4
- R12: C8 <= 2
- R13: C9 <= 2
- R14: C10 <= 2
- R15: C11 <= 2
+ R8: C8 <= -1
+ R9: C9 <= -1
+ R10: C10 <= -1
+ R11: C11 <= -1
 Bounds
  C0 free
  C1 free
@@ -48,10 +43,10 @@ GUROBI
 Minimize
   X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
 Subject To
- 31[0,0]: minimum_1 >= -2
- 31[0,1]: minimum_2 >= -2
- 31[1,0]: minimum_3 >= -2
- 31[1,1]: minimum_4 >= -2
+ 16[0,0]: minimum_1 >= 1
+ 16[0,1]: minimum_2 >= 1
+ 16[1,0]: minimum_3 >= 1
+ 16[1,1]: minimum_4 >= 1
 Bounds
  X[0,0] free
  X[0,1] free
@@ -66,8 +61,8 @@ Bounds
  minimum_3 free
  minimum_4 free
 General Constraints
- GC0: minimum_1 = MIN ( X[0,0] , Y[0,0] , 1 )
- GC1: minimum_2 = MIN ( X[0,1] , Y[0,1] , -2 )
- GC2: minimum_3 = MIN ( X[1,0] , Y[1,0] , 3 )
- GC3: minimum_4 = MIN ( X[1,1] , Y[1,1] , 4 )
+ GC0: minimum_1 = MIN ( X[0,0] , Y[0,0] )
+ GC1: minimum_2 = MIN ( X[0,1] , Y[0,1] )
+ GC2: minimum_3 = MIN ( X[1,0] , Y[1,0] )
+ GC3: minimum_4 = MIN ( X[1,1] , Y[1,1] )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum34__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum34__0.txt
@@ -1,10 +1,9 @@
 CVXPY
 Minimize
-  Sum(X, None, False)
+  Sum(X + Y, None, False)
 Subject To
- 38: -Y <= minimum(X, [[1.00 -2.00]
- [3.00 4.00]])
- 43: Y == 2.0
+ 23: [[1.00 -2.00]
+ [3.00 4.00]] <= minimum(X, Y)
 Bounds
  X free
  Y free
@@ -12,24 +11,20 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C1 + C2 + C3
+  C0 + C1 + C2 + C3 + C4 + C5 + C6 + C7
 Subject To
- R0: C8 = 2
- R1: C9 = 2
- R2: C10 = 2
- R3: C11 = 2
- R4: - C0 - C4 <= 0
- R5: - C1 - C5 <= 0
- R6: - C2 - C6 <= 0
- R7: - C3 - C7 <= 0
- R8: - C4 <= 1
- R9: - C5 <= 3
- R10: - C6 <= -2
- R11: - C7 <= 4
- R12: C4 - C8 <= 0
- R13: C5 - C9 <= 0
- R14: C6 - C10 <= 0
- R15: C7 - C11 <= 0
+ R0: - C0 - C8 <= 0
+ R1: - C1 - C9 <= 0
+ R2: - C2 - C10 <= 0
+ R3: - C3 - C11 <= 0
+ R4: - C4 - C8 <= 0
+ R5: - C5 - C9 <= 0
+ R6: - C6 - C10 <= 0
+ R7: - C7 - C11 <= 0
+ R8: C8 <= -1
+ R9: C9 <= -3
+ R10: C10 <= 2
+ R11: C11 <= -4
 Bounds
  C0 free
  C1 free
@@ -47,16 +42,12 @@ End
 ----------------------------------------
 GUROBI
 Minimize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
 Subject To
- 38[0,0]: - Y[0,0] - minimum_1 <= 0
- 38[0,1]: - Y[0,1] - minimum_2 <= 0
- 38[1,0]: - Y[1,0] - minimum_3 <= 0
- 38[1,1]: - Y[1,1] - minimum_4 <= 0
- 43[0,0]: Y[0,0] = 2
- 43[0,1]: Y[0,1] = 2
- 43[1,0]: Y[1,0] = 2
- 43[1,1]: Y[1,1] = 2
+ 23[0,0]: minimum_1 >= 1
+ 23[0,1]: minimum_2 >= -2
+ 23[1,0]: minimum_3 >= 3
+ 23[1,1]: minimum_4 >= 4
 Bounds
  X[0,0] free
  X[0,1] free
@@ -71,8 +62,8 @@ Bounds
  minimum_3 free
  minimum_4 free
 General Constraints
- GC0: minimum_1 = MIN ( X[0,0] , 1 )
- GC1: minimum_2 = MIN ( X[0,1] , -2 )
- GC2: minimum_3 = MIN ( X[1,0] , 3 )
- GC3: minimum_4 = MIN ( X[1,1] , 4 )
+ GC0: minimum_1 = MIN ( X[0,0] , Y[0,0] )
+ GC1: minimum_2 = MIN ( X[0,1] , Y[0,1] )
+ GC2: minimum_3 = MIN ( X[1,0] , Y[1,0] )
+ GC3: minimum_4 = MIN ( X[1,1] , Y[1,1] )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum35__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum35__0.txt
@@ -1,58 +1,73 @@
 CVXPY
 Minimize
-  Sum(X, None, False)
+  Sum(X + Y, None, False)
 Subject To
- 50: -2.0 <= minimum([[1.00 -2.00]
- [3.00 4.00]], [[2.00 -1.00]
- [1.00 3.00]])
- 55: X == 1.0
+ 31: -2.0 <= minimum(X, Y, [[1.00 -2.00]
+ [3.00 4.00]])
 Bounds
  X free
+ Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  C0 + C1 + C2 + C3
+  C0 + C1 + C2 + C3 + C4 + C5 + C6 + C7
 Subject To
- R0: C0 = 1
- R1: C1 = 1
- R2: C2 = 1
- R3: C3 = 1
- R4: <= 3
- R5: <= 3
- R6: <= 0
- R7: <= 5
+ R0: - C0 - C8 <= 0
+ R1: - C1 - C9 <= 0
+ R2: - C2 - C10 <= 0
+ R3: - C3 - C11 <= 0
+ R4: - C4 - C8 <= 0
+ R5: - C5 - C9 <= 0
+ R6: - C6 - C10 <= 0
+ R7: - C7 - C11 <= 0
+ R8: - C8 <= 1
+ R9: - C9 <= 3
+ R10: - C10 <= -2
+ R11: - C11 <= 4
+ R12: C8 <= 2
+ R13: C9 <= 2
+ R14: C10 <= 2
+ R15: C11 <= 2
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
 End
 ----------------------------------------
 GUROBI
 Minimize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
 Subject To
- 50[0,0]: minimum_1 >= -2
- 50[0,1]: minimum_2 >= -2
- 50[1,0]: minimum_3 >= -2
- 50[1,1]: minimum_4 >= -2
- 55[0,0]: X[0,0] = 1
- 55[0,1]: X[0,1] = 1
- 55[1,0]: X[1,0] = 1
- 55[1,1]: X[1,1] = 1
+ 31[0,0]: minimum_1 >= -2
+ 31[0,1]: minimum_2 >= -2
+ 31[1,0]: minimum_3 >= -2
+ 31[1,1]: minimum_4 >= -2
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
+ Y[0,0] free
+ Y[0,1] free
+ Y[1,0] free
+ Y[1,1] free
  minimum_1 free
  minimum_2 free
  minimum_3 free
  minimum_4 free
 General Constraints
- GC0: minimum_1 = MIN ( 1 )
- GC1: minimum_2 = MIN ( -2 )
- GC2: minimum_3 = MIN ( 1 )
- GC3: minimum_4 = MIN ( 3 )
+ GC0: minimum_1 = MIN ( X[0,0] , Y[0,0] , 1 )
+ GC1: minimum_2 = MIN ( X[0,1] , Y[0,1] , -2 )
+ GC2: minimum_3 = MIN ( X[1,0] , Y[1,0] , 3 )
+ GC3: minimum_4 = MIN ( X[1,1] , Y[1,1] , 4 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum36__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum36__0.txt
@@ -2,29 +2,34 @@ CVXPY
 Minimize
   Sum(X, None, False)
 Subject To
- 63: -2.0 <= minimum(X + [[1.00 -2.00]
- [3.00 4.00]], [[1.00 -2.00]
+ 38: -Y <= minimum(X, [[1.00 -2.00]
  [3.00 4.00]])
+ 43: Y == 2.0
 Bounds
  X free
+ Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
   C0 + C1 + C2 + C3
 Subject To
- R0: - C0 - C4 <= 1
- R1: - C1 - C5 <= 3
- R2: - C2 - C6 <= -2
- R3: - C3 - C7 <= 4
- R4: - C4 <= 1
- R5: - C5 <= 3
- R6: - C6 <= -2
- R7: - C7 <= 4
- R8: C4 <= 2
- R9: C5 <= 2
- R10: C6 <= 2
- R11: C7 <= 2
+ R0: C8 = 2
+ R1: C9 = 2
+ R2: C10 = 2
+ R3: C11 = 2
+ R4: - C0 - C4 <= 0
+ R5: - C1 - C5 <= 0
+ R6: - C2 - C6 <= 0
+ R7: - C3 - C7 <= 0
+ R8: - C4 <= 1
+ R9: - C5 <= 3
+ R10: - C6 <= -2
+ R11: - C7 <= 4
+ R12: C4 - C8 <= 0
+ R13: C5 - C9 <= 0
+ R14: C6 - C10 <= 0
+ R15: C7 - C11 <= 0
 Bounds
  C0 free
  C1 free
@@ -34,36 +39,40 @@ Bounds
  C5 free
  C6 free
  C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
 End
 ----------------------------------------
 GUROBI
 Minimize
   X[0,0] + X[0,1] + X[1,0] + X[1,1]
 Subject To
- R0: - X[0,0] + index_1 = 1
- R1: - X[0,1] + index_3 = -2
- R2: - X[1,0] + index_5 = 3
- R3: - X[1,1] + index_7 = 4
- 63[0,0]: minimum_2 >= -2
- 63[0,1]: minimum_4 >= -2
- 63[1,0]: minimum_6 >= -2
- 63[1,1]: minimum_8 >= -2
+ 38[0,0]: - Y[0,0] - minimum_1 <= 0
+ 38[0,1]: - Y[0,1] - minimum_2 <= 0
+ 38[1,0]: - Y[1,0] - minimum_3 <= 0
+ 38[1,1]: - Y[1,1] - minimum_4 <= 0
+ 43[0,0]: Y[0,0] = 2
+ 43[0,1]: Y[0,1] = 2
+ 43[1,0]: Y[1,0] = 2
+ 43[1,1]: Y[1,1] = 2
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- index_1 free
+ Y[0,0] free
+ Y[0,1] free
+ Y[1,0] free
+ Y[1,1] free
+ minimum_1 free
  minimum_2 free
- index_3 free
+ minimum_3 free
  minimum_4 free
- index_5 free
- minimum_6 free
- index_7 free
- minimum_8 free
 General Constraints
- GC0: minimum_2 = MIN ( index_1 , 1 )
- GC1: minimum_4 = MIN ( index_3 , -2 )
- GC2: minimum_6 = MIN ( index_5 , 3 )
- GC3: minimum_8 = MIN ( index_7 , 4 )
+ GC0: minimum_1 = MIN ( X[0,0] , 1 )
+ GC1: minimum_2 = MIN ( X[0,1] , -2 )
+ GC2: minimum_3 = MIN ( X[1,0] , 3 )
+ GC3: minimum_4 = MIN ( X[1,1] , 4 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum37__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum37__0.txt
@@ -1,60 +1,58 @@
 CVXPY
-Maximize
+Minimize
   Sum(X, None, False)
 Subject To
- 6: maximum(X, [[1.00 -2.00]
- [3.00 4.00]]) <= 4.0
+ 50: -2.0 <= minimum([[1.00 -2.00]
+ [3.00 4.00]], [[2.00 -1.00]
+ [1.00 3.00]])
+ 55: X == 1.0
 Bounds
  X free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1 - C2 - C3
+  C0 + C1 + C2 + C3
 Subject To
- R0: C0 - C4 <= 0
- R1: C1 - C5 <= 0
- R2: C2 - C6 <= 0
- R3: C3 - C7 <= 0
- R4: - C4 <= -1
- R5: - C5 <= -3
- R6: - C6 <= 2
- R7: - C7 <= -4
- R8: C4 <= 4
- R9: C5 <= 4
- R10: C6 <= 4
- R11: C7 <= 4
+ R0: C0 = 1
+ R1: C1 = 1
+ R2: C2 = 1
+ R3: C3 = 1
+ R4: <= 3
+ R5: <= 3
+ R6: <= 0
+ R7: <= 5
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
- C4 free
- C5 free
- C6 free
- C7 free
 End
 ----------------------------------------
 GUROBI
-Maximize
+Minimize
   X[0,0] + X[0,1] + X[1,0] + X[1,1]
 Subject To
- 6[0,0]: maximum_1 <= 4
- 6[0,1]: maximum_2 <= 4
- 6[1,0]: maximum_3 <= 4
- 6[1,1]: maximum_4 <= 4
+ 50[0,0]: minimum_1 >= -2
+ 50[0,1]: minimum_2 >= -2
+ 50[1,0]: minimum_3 >= -2
+ 50[1,1]: minimum_4 >= -2
+ 55[0,0]: X[0,0] = 1
+ 55[0,1]: X[0,1] = 1
+ 55[1,0]: X[1,0] = 1
+ 55[1,1]: X[1,1] = 1
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- maximum_1 free
- maximum_2 free
- maximum_3 free
- maximum_4 free
+ minimum_1 free
+ minimum_2 free
+ minimum_3 free
+ minimum_4 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0,0] , 1 )
- GC1: maximum_2 = MAX ( X[0,1] , -2 )
- GC2: maximum_3 = MAX ( X[1,0] , 3 )
- GC3: maximum_4 = MAX ( X[1,1] , 4 )
+ GC0: minimum_1 = MIN ( 1 )
+ GC1: minimum_2 = MIN ( -2 )
+ GC2: minimum_3 = MIN ( 1 )
+ GC3: minimum_4 = MIN ( 3 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum38__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum38__0.txt
@@ -1,29 +1,30 @@
 CVXPY
-Maximize
-  Sum(X + Y, None, False)
+Minimize
+  Sum(X, None, False)
 Subject To
- 14: maximum(X, Y) <= 1.0
+ 63: -2.0 <= minimum(X + [[1.00 -2.00]
+ [3.00 4.00]], [[1.00 -2.00]
+ [3.00 4.00]])
 Bounds
  X free
- Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1 - C2 - C3 - C4 - C5 - C6 - C7
+  C0 + C1 + C2 + C3
 Subject To
- R0: C0 - C8 <= 0
- R1: C1 - C9 <= 0
- R2: C2 - C10 <= 0
- R3: C3 - C11 <= 0
- R4: C4 - C8 <= 0
- R5: C5 - C9 <= 0
- R6: C6 - C10 <= 0
- R7: C7 - C11 <= 0
- R8: C8 <= 1
- R9: C9 <= 1
- R10: C10 <= 1
- R11: C11 <= 1
+ R0: - C0 - C4 <= 1
+ R1: - C1 - C5 <= 3
+ R2: - C2 - C6 <= -2
+ R3: - C3 - C7 <= 4
+ R4: - C4 <= 1
+ R5: - C5 <= 3
+ R6: - C6 <= -2
+ R7: - C7 <= 4
+ R8: C4 <= 2
+ R9: C5 <= 2
+ R10: C6 <= 2
+ R11: C7 <= 2
 Bounds
  C0 free
  C1 free
@@ -33,36 +34,36 @@ Bounds
  C5 free
  C6 free
  C7 free
- C8 free
- C9 free
- C10 free
- C11 free
 End
 ----------------------------------------
 GUROBI
-Maximize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
+Minimize
+  X[0,0] + X[0,1] + X[1,0] + X[1,1]
 Subject To
- 14[0,0]: maximum_1 <= 1
- 14[0,1]: maximum_2 <= 1
- 14[1,0]: maximum_3 <= 1
- 14[1,1]: maximum_4 <= 1
+ R0: - X[0,0] + index_1 = 1
+ R1: - X[0,1] + index_3 = -2
+ R2: - X[1,0] + index_5 = 3
+ R3: - X[1,1] + index_7 = 4
+ 63[0,0]: minimum_2 >= -2
+ 63[0,1]: minimum_4 >= -2
+ 63[1,0]: minimum_6 >= -2
+ 63[1,1]: minimum_8 >= -2
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- Y[0,0] free
- Y[0,1] free
- Y[1,0] free
- Y[1,1] free
- maximum_1 free
- maximum_2 free
- maximum_3 free
- maximum_4 free
+ index_1 free
+ minimum_2 free
+ index_3 free
+ minimum_4 free
+ index_5 free
+ minimum_6 free
+ index_7 free
+ minimum_8 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0,0] , Y[0,0] )
- GC1: maximum_2 = MAX ( X[0,1] , Y[0,1] )
- GC2: maximum_3 = MAX ( X[1,0] , Y[1,0] )
- GC3: maximum_4 = MAX ( X[1,1] , Y[1,1] )
+ GC0: minimum_2 = MIN ( index_1 , 1 )
+ GC1: minimum_4 = MIN ( index_3 , -2 )
+ GC2: minimum_6 = MIN ( index_5 , 3 )
+ GC3: minimum_8 = MIN ( index_7 , 4 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum39__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum39__0.txt
@@ -1,30 +1,35 @@
 CVXPY
-Maximize
-  Sum(X + Y, None, False)
+Minimize
+  Sum(X, None, False)
 Subject To
- 21: maximum(X, Y) <= [[1.00 -2.00]
- [3.00 4.00]]
+ 70: 0.0 <= minimum(X, z, 1.0)
+ 74: z == 1.0
 Bounds
  X free
- Y free
+ z free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1 - C2 - C3 - C4 - C5 - C6 - C7
+  C0 + C1 + C2 + C3
 Subject To
- R0: C0 - C8 <= 0
- R1: C1 - C9 <= 0
- R2: C2 - C10 <= 0
- R3: C3 - C11 <= 0
- R4: C4 - C8 <= 0
- R5: C5 - C9 <= 0
- R6: C6 - C10 <= 0
- R7: C7 - C11 <= 0
- R8: C8 <= 1
- R9: C9 <= 3
- R10: C10 <= -2
- R11: C11 <= 4
+ R0: C8 = 1
+ R1: - C0 - C4 <= 0
+ R2: - C1 - C5 <= 0
+ R3: - C2 - C6 <= 0
+ R4: - C3 - C7 <= 0
+ R5: - C4 - C8 <= 0
+ R6: - C5 - C8 <= 0
+ R7: - C6 - C8 <= 0
+ R8: - C7 - C8 <= 0
+ R9: - C4 <= 1
+ R10: - C5 <= 1
+ R11: - C6 <= 1
+ R12: - C7 <= 1
+ R13: C4 <= 0
+ R14: C5 <= 0
+ R15: C6 <= 0
+ R16: C7 <= 0
 Bounds
  C0 free
  C1 free
@@ -35,35 +40,30 @@ Bounds
  C6 free
  C7 free
  C8 free
- C9 free
- C10 free
- C11 free
 End
 ----------------------------------------
 GUROBI
-Maximize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
+Minimize
+  X[0,0] + X[0,1] + X[1,0] + X[1,1]
 Subject To
- 21[0,0]: maximum_1 <= 1
- 21[0,1]: maximum_2 <= -2
- 21[1,0]: maximum_3 <= 3
- 21[1,1]: maximum_4 <= 4
+ 70[0,0]: minimum_1 >= 0
+ 70[0,1]: minimum_2 >= 0
+ 70[1,0]: minimum_3 >= 0
+ 70[1,1]: minimum_4 >= 0
+ 74: z = 1
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- Y[0,0] free
- Y[0,1] free
- Y[1,0] free
- Y[1,1] free
- maximum_1 free
- maximum_2 free
- maximum_3 free
- maximum_4 free
+ z free
+ minimum_1 free
+ minimum_2 free
+ minimum_3 free
+ minimum_4 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0,0] , Y[0,0] )
- GC1: maximum_2 = MAX ( X[0,1] , Y[0,1] )
- GC2: maximum_3 = MAX ( X[1,0] , Y[1,0] )
- GC3: maximum_4 = MAX ( X[1,1] , Y[1,1] )
+ GC0: minimum_1 = MIN ( X[0,0] , z , 1 )
+ GC1: minimum_2 = MIN ( X[0,1] , z , 1 )
+ GC2: minimum_3 = MIN ( X[1,0] , z , 1 )
+ GC3: minimum_4 = MIN ( X[1,1] , z , 1 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum41__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum41__0.txt
@@ -1,10 +1,8 @@
 CVXPY
 Maximize
-  Sum(X, None, False)
+  Sum(X + Y, None, False)
 Subject To
- 35: maximum(X, [[1.00 -2.00]
- [3.00 4.00]]) <= Y
- 40: Y == 4.0
+ 14: maximum(X, Y) <= 1.0
 Bounds
  X free
  Y free
@@ -12,24 +10,20 @@ End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1 - C2 - C3
+  - C0 - C1 - C2 - C3 - C4 - C5 - C6 - C7
 Subject To
- R0: C8 = 4
- R1: C9 = 4
- R2: C10 = 4
- R3: C11 = 4
- R4: C0 - C4 <= 0
- R5: C1 - C5 <= 0
- R6: C2 - C6 <= 0
- R7: C3 - C7 <= 0
- R8: - C4 <= -1
- R9: - C5 <= -3
- R10: - C6 <= 2
- R11: - C7 <= -4
- R12: C4 - C8 <= 0
- R13: C5 - C9 <= 0
- R14: C6 - C10 <= 0
- R15: C7 - C11 <= 0
+ R0: C0 - C8 <= 0
+ R1: C1 - C9 <= 0
+ R2: C2 - C10 <= 0
+ R3: C3 - C11 <= 0
+ R4: C4 - C8 <= 0
+ R5: C5 - C9 <= 0
+ R6: C6 - C10 <= 0
+ R7: C7 - C11 <= 0
+ R8: C8 <= 1
+ R9: C9 <= 1
+ R10: C10 <= 1
+ R11: C11 <= 1
 Bounds
  C0 free
  C1 free
@@ -47,32 +41,28 @@ End
 ----------------------------------------
 GUROBI
 Maximize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
 Subject To
- 35[0,0]: maximum_1 - Y[0,0] <= 0
- 35[0,1]: maximum_2 - Y[0,1] <= 0
- 35[1,0]: maximum_3 - Y[1,0] <= 0
- 35[1,1]: maximum_4 - Y[1,1] <= 0
- 40[0,0]: Y[0,0] = 4
- 40[0,1]: Y[0,1] = 4
- 40[1,0]: Y[1,0] = 4
- 40[1,1]: Y[1,1] = 4
+ 14[0,0]: maximum_1 <= 1
+ 14[0,1]: maximum_2 <= 1
+ 14[1,0]: maximum_3 <= 1
+ 14[1,1]: maximum_4 <= 1
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- maximum_1 free
- maximum_2 free
- maximum_3 free
- maximum_4 free
  Y[0,0] free
  Y[0,1] free
  Y[1,0] free
  Y[1,1] free
+ maximum_1 free
+ maximum_2 free
+ maximum_3 free
+ maximum_4 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0,0] , 1 )
- GC1: maximum_2 = MAX ( X[0,1] , -2 )
- GC2: maximum_3 = MAX ( X[1,0] , 3 )
- GC3: maximum_4 = MAX ( X[1,1] , 4 )
+ GC0: maximum_1 = MAX ( X[0,0] , Y[0,0] )
+ GC1: maximum_2 = MAX ( X[0,1] , Y[0,1] )
+ GC2: maximum_3 = MAX ( X[1,0] , Y[1,0] )
+ GC3: maximum_4 = MAX ( X[1,1] , Y[1,1] )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum42__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum42__0.txt
@@ -1,58 +1,69 @@
 CVXPY
 Maximize
-  Sum(X, None, False)
+  Sum(X + Y, None, False)
 Subject To
- 47: maximum([[1.00 -2.00]
- [3.00 4.00]], [[2.00 -1.00]
- [1.00 3.00]]) <= 4.0
- 52: X == 1.0
+ 21: maximum(X, Y) <= [[1.00 -2.00]
+ [3.00 4.00]]
 Bounds
  X free
+ Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1 - C2 - C3
+  - C0 - C1 - C2 - C3 - C4 - C5 - C6 - C7
 Subject To
- R0: C0 = 1
- R1: C1 = 1
- R2: C2 = 1
- R3: C3 = 1
- R4: <= 2
- R5: <= 1
- R6: <= 5
- R7: <= 0
+ R0: C0 - C8 <= 0
+ R1: C1 - C9 <= 0
+ R2: C2 - C10 <= 0
+ R3: C3 - C11 <= 0
+ R4: C4 - C8 <= 0
+ R5: C5 - C9 <= 0
+ R6: C6 - C10 <= 0
+ R7: C7 - C11 <= 0
+ R8: C8 <= 1
+ R9: C9 <= 3
+ R10: C10 <= -2
+ R11: C11 <= 4
 Bounds
  C0 free
  C1 free
  C2 free
  C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
 End
 ----------------------------------------
 GUROBI
 Maximize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
 Subject To
- 47[0,0]: maximum_1 <= 4
- 47[0,1]: maximum_2 <= 4
- 47[1,0]: maximum_3 <= 4
- 47[1,1]: maximum_4 <= 4
- 52[0,0]: X[0,0] = 1
- 52[0,1]: X[0,1] = 1
- 52[1,0]: X[1,0] = 1
- 52[1,1]: X[1,1] = 1
+ 21[0,0]: maximum_1 <= 1
+ 21[0,1]: maximum_2 <= -2
+ 21[1,0]: maximum_3 <= 3
+ 21[1,1]: maximum_4 <= 4
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
+ Y[0,0] free
+ Y[0,1] free
+ Y[1,0] free
+ Y[1,1] free
  maximum_1 free
  maximum_2 free
  maximum_3 free
  maximum_4 free
 General Constraints
- GC0: maximum_1 = MAX ( 2 )
- GC1: maximum_2 = MAX ( -1 )
- GC2: maximum_3 = MAX ( 3 )
- GC3: maximum_4 = MAX ( 4 )
+ GC0: maximum_1 = MAX ( X[0,0] , Y[0,0] )
+ GC1: maximum_2 = MAX ( X[0,1] , Y[0,1] )
+ GC2: maximum_3 = MAX ( X[1,0] , Y[1,0] )
+ GC3: maximum_4 = MAX ( X[1,1] , Y[1,1] )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum43__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum43__0.txt
@@ -1,30 +1,34 @@
 CVXPY
 Maximize
-  Sum(X, None, False)
+  Sum(X + Y, None, False)
 Subject To
- 60: maximum(X + [[1.00 -2.00]
- [3.00 4.00]], [[1.00 -2.00]
+ 29: maximum(X, Y, [[1.00 -2.00]
  [3.00 4.00]]) <= 4.0
 Bounds
  X free
+ Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
-  - C0 - C1 - C2 - C3
+  - C0 - C1 - C2 - C3 - C4 - C5 - C6 - C7
 Subject To
- R0: C0 - C4 <= -1
- R1: C1 - C5 <= -3
- R2: C2 - C6 <= 2
- R3: C3 - C7 <= -4
- R4: - C4 <= -1
- R5: - C5 <= -3
- R6: - C6 <= 2
- R7: - C7 <= -4
- R8: C4 <= 4
- R9: C5 <= 4
- R10: C6 <= 4
- R11: C7 <= 4
+ R0: C0 - C8 <= 0
+ R1: C1 - C9 <= 0
+ R2: C2 - C10 <= 0
+ R3: C3 - C11 <= 0
+ R4: C4 - C8 <= 0
+ R5: C5 - C9 <= 0
+ R6: C6 - C10 <= 0
+ R7: C7 - C11 <= 0
+ R8: - C8 <= -1
+ R9: - C9 <= -3
+ R10: - C10 <= 2
+ R11: - C11 <= -4
+ R12: C8 <= 4
+ R13: C9 <= 4
+ R14: C10 <= 4
+ R15: C11 <= 4
 Bounds
  C0 free
  C1 free
@@ -34,36 +38,36 @@ Bounds
  C5 free
  C6 free
  C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
 End
 ----------------------------------------
 GUROBI
 Maximize
-  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+  X[0,0] + X[0,1] + X[1,0] + X[1,1] + Y[0,0] + Y[0,1] + Y[1,0] + Y[1,1]
 Subject To
- R0: - X[0,0] + index_1 = 1
- R1: - X[0,1] + index_3 = -2
- R2: - X[1,0] + index_5 = 3
- R3: - X[1,1] + index_7 = 4
- 60[0,0]: maximum_2 <= 4
- 60[0,1]: maximum_4 <= 4
- 60[1,0]: maximum_6 <= 4
- 60[1,1]: maximum_8 <= 4
+ 29[0,0]: maximum_1 <= 4
+ 29[0,1]: maximum_2 <= 4
+ 29[1,0]: maximum_3 <= 4
+ 29[1,1]: maximum_4 <= 4
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- index_1 free
+ Y[0,0] free
+ Y[0,1] free
+ Y[1,0] free
+ Y[1,1] free
+ maximum_1 free
  maximum_2 free
- index_3 free
+ maximum_3 free
  maximum_4 free
- index_5 free
- maximum_6 free
- index_7 free
- maximum_8 free
 General Constraints
- GC0: maximum_2 = MAX ( index_1 , 1 )
- GC1: maximum_4 = MAX ( index_3 , -2 )
- GC2: maximum_6 = MAX ( index_5 , 3 )
- GC3: maximum_8 = MAX ( index_7 , 4 )
+ GC0: maximum_1 = MAX ( X[0,0] , Y[0,0] , 1 )
+ GC1: maximum_2 = MAX ( X[0,1] , Y[0,1] , -2 )
+ GC2: maximum_3 = MAX ( X[1,0] , Y[1,0] , 3 )
+ GC3: maximum_4 = MAX ( X[1,1] , Y[1,1] , 4 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum44__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum44__0.txt
@@ -2,28 +2,34 @@ CVXPY
 Maximize
   Sum(X, None, False)
 Subject To
- 6: maximum(X, [[1.00 -2.00]
- [3.00 4.00]]) <= 4.0
+ 35: maximum(X, [[1.00 -2.00]
+ [3.00 4.00]]) <= Y
+ 40: Y == 4.0
 Bounds
  X free
+ Y free
 End
 ----------------------------------------
 AFTER COMPILATION
 Minimize
   - C0 - C1 - C2 - C3
 Subject To
- R0: C0 - C4 <= 0
- R1: C1 - C5 <= 0
- R2: C2 - C6 <= 0
- R3: C3 - C7 <= 0
- R4: - C4 <= -1
- R5: - C5 <= -3
- R6: - C6 <= 2
- R7: - C7 <= -4
- R8: C4 <= 4
- R9: C5 <= 4
- R10: C6 <= 4
- R11: C7 <= 4
+ R0: C8 = 4
+ R1: C9 = 4
+ R2: C10 = 4
+ R3: C11 = 4
+ R4: C0 - C4 <= 0
+ R5: C1 - C5 <= 0
+ R6: C2 - C6 <= 0
+ R7: C3 - C7 <= 0
+ R8: - C4 <= -1
+ R9: - C5 <= -3
+ R10: - C6 <= 2
+ R11: - C7 <= -4
+ R12: C4 - C8 <= 0
+ R13: C5 - C9 <= 0
+ R14: C6 - C10 <= 0
+ R15: C7 - C11 <= 0
 Bounds
  C0 free
  C1 free
@@ -33,16 +39,24 @@ Bounds
  C5 free
  C6 free
  C7 free
+ C8 free
+ C9 free
+ C10 free
+ C11 free
 End
 ----------------------------------------
 GUROBI
 Maximize
   X[0,0] + X[0,1] + X[1,0] + X[1,1]
 Subject To
- 6[0,0]: maximum_1 <= 4
- 6[0,1]: maximum_2 <= 4
- 6[1,0]: maximum_3 <= 4
- 6[1,1]: maximum_4 <= 4
+ 35[0,0]: maximum_1 - Y[0,0] <= 0
+ 35[0,1]: maximum_2 - Y[0,1] <= 0
+ 35[1,0]: maximum_3 - Y[1,0] <= 0
+ 35[1,1]: maximum_4 - Y[1,1] <= 0
+ 40[0,0]: Y[0,0] = 4
+ 40[0,1]: Y[0,1] = 4
+ 40[1,0]: Y[1,0] = 4
+ 40[1,1]: Y[1,1] = 4
 Bounds
  X[0,0] free
  X[0,1] free
@@ -52,6 +66,10 @@ Bounds
  maximum_2 free
  maximum_3 free
  maximum_4 free
+ Y[0,0] free
+ Y[0,1] free
+ Y[1,0] free
+ Y[1,1] free
 General Constraints
  GC0: maximum_1 = MAX ( X[0,0] , 1 )
  GC1: maximum_2 = MAX ( X[0,1] , -2 )

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum45__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum45__0.txt
@@ -1,0 +1,58 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 47: maximum([[1.00 -2.00]
+ [3.00 4.00]], [[2.00 -1.00]
+ [1.00 3.00]]) <= 4.0
+ 52: X == 1.0
+Bounds
+ X free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  - C0 - C1 - C2 - C3
+Subject To
+ R0: C0 = 1
+ R1: C1 = 1
+ R2: C2 = 1
+ R3: C3 = 1
+ R4: <= 2
+ R5: <= 1
+ R6: <= 5
+ R7: <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+Subject To
+ 47[0,0]: maximum_1 <= 4
+ 47[0,1]: maximum_2 <= 4
+ 47[1,0]: maximum_3 <= 4
+ 47[1,1]: maximum_4 <= 4
+ 52[0,0]: X[0,0] = 1
+ 52[0,1]: X[0,1] = 1
+ 52[1,0]: X[1,0] = 1
+ 52[1,1]: X[1,1] = 1
+Bounds
+ X[0,0] free
+ X[0,1] free
+ X[1,0] free
+ X[1,1] free
+ maximum_1 free
+ maximum_2 free
+ maximum_3 free
+ maximum_4 free
+General Constraints
+ GC0: maximum_1 = MAX ( 2 )
+ GC1: maximum_2 = MAX ( -1 )
+ GC2: maximum_3 = MAX ( 3 )
+ GC3: maximum_4 = MAX ( 4 )
+End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum46__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum46__0.txt
@@ -2,7 +2,8 @@ CVXPY
 Maximize
   Sum(X, None, False)
 Subject To
- 6: maximum(X, [[1.00 -2.00]
+ 60: maximum(X + [[1.00 -2.00]
+ [3.00 4.00]], [[1.00 -2.00]
  [3.00 4.00]]) <= 4.0
 Bounds
  X free
@@ -12,10 +13,10 @@ AFTER COMPILATION
 Minimize
   - C0 - C1 - C2 - C3
 Subject To
- R0: C0 - C4 <= 0
- R1: C1 - C5 <= 0
- R2: C2 - C6 <= 0
- R3: C3 - C7 <= 0
+ R0: C0 - C4 <= -1
+ R1: C1 - C5 <= -3
+ R2: C2 - C6 <= 2
+ R3: C3 - C7 <= -4
  R4: - C4 <= -1
  R5: - C5 <= -3
  R6: - C6 <= 2
@@ -39,22 +40,30 @@ GUROBI
 Maximize
   X[0,0] + X[0,1] + X[1,0] + X[1,1]
 Subject To
- 6[0,0]: maximum_1 <= 4
- 6[0,1]: maximum_2 <= 4
- 6[1,0]: maximum_3 <= 4
- 6[1,1]: maximum_4 <= 4
+ R0: - X[0,0] + index_1 = 1
+ R1: - X[0,1] + index_3 = -2
+ R2: - X[1,0] + index_5 = 3
+ R3: - X[1,1] + index_7 = 4
+ 60[0,0]: maximum_2 <= 4
+ 60[0,1]: maximum_4 <= 4
+ 60[1,0]: maximum_6 <= 4
+ 60[1,1]: maximum_8 <= 4
 Bounds
  X[0,0] free
  X[0,1] free
  X[1,0] free
  X[1,1] free
- maximum_1 free
+ index_1 free
  maximum_2 free
- maximum_3 free
+ index_3 free
  maximum_4 free
+ index_5 free
+ maximum_6 free
+ index_7 free
+ maximum_8 free
 General Constraints
- GC0: maximum_1 = MAX ( X[0,0] , 1 )
- GC1: maximum_2 = MAX ( X[0,1] , -2 )
- GC2: maximum_3 = MAX ( X[1,0] , 3 )
- GC3: maximum_4 = MAX ( X[1,1] , 4 )
+ GC0: maximum_2 = MAX ( index_1 , 1 )
+ GC1: maximum_4 = MAX ( index_3 , -2 )
+ GC2: maximum_6 = MAX ( index_5 , 3 )
+ GC3: maximum_8 = MAX ( index_7 , 4 )
 End

--- a/tests/snapshots/all__lp_genexpr_minimum_maximum47__0.txt
+++ b/tests/snapshots/all__lp_genexpr_minimum_maximum47__0.txt
@@ -1,0 +1,69 @@
+CVXPY
+Maximize
+  Sum(X, None, False)
+Subject To
+ 67: maximum(X, z, 1.0) <= 2.0
+ 71: z == 1.0
+Bounds
+ X free
+ z free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  - C0 - C1 - C2 - C3
+Subject To
+ R0: C8 = 1
+ R1: C0 - C4 <= 0
+ R2: C1 - C5 <= 0
+ R3: C2 - C6 <= 0
+ R4: C3 - C7 <= 0
+ R5: - C4 + C8 <= 0
+ R6: - C5 + C8 <= 0
+ R7: - C6 + C8 <= 0
+ R8: - C7 + C8 <= 0
+ R9: - C4 <= -1
+ R10: - C5 <= -1
+ R11: - C6 <= -1
+ R12: - C7 <= -1
+ R13: C4 <= 2
+ R14: C5 <= 2
+ R15: C6 <= 2
+ R16: C7 <= 2
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+ C6 free
+ C7 free
+ C8 free
+End
+----------------------------------------
+GUROBI
+Maximize
+  X[0,0] + X[0,1] + X[1,0] + X[1,1]
+Subject To
+ 67[0,0]: maximum_1 <= 2
+ 67[0,1]: maximum_2 <= 2
+ 67[1,0]: maximum_3 <= 2
+ 67[1,1]: maximum_4 <= 2
+ 71: z = 1
+Bounds
+ X[0,0] free
+ X[0,1] free
+ X[1,0] free
+ X[1,1] free
+ z free
+ maximum_1 free
+ maximum_2 free
+ maximum_3 free
+ maximum_4 free
+General Constraints
+ GC0: maximum_1 = MAX ( X[0,0] , z , 1 )
+ GC1: maximum_2 = MAX ( X[0,1] , z , 1 )
+ GC2: maximum_3 = MAX ( X[1,0] , z , 1 )
+ GC3: maximum_4 = MAX ( X[1,1] , z , 1 )
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -346,6 +346,7 @@ def genexpr_minimum_maximum() -> Iterator[cp.Problem]:
     reset_id_counter()
     x = cp.Variable(2, name="X")
     y = cp.Variable(2, name="Y")
+    z = cp.Variable(name="z")
     A = np.array([2, -1])
 
     yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(x, A) >= -1])
@@ -354,6 +355,7 @@ def genexpr_minimum_maximum() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(x + y)), [cp.minimum(x, y, A) >= -1])
     yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(x, A) >= -y, y == 1])
     yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(x + A, A) >= -1])
+    yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(x, z, 1) >= 0, z == 1])
 
     reset_id_counter()
 
@@ -363,6 +365,7 @@ def genexpr_minimum_maximum() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Maximize(cp.sum(x + y)), [cp.maximum(x, y, A) <= 2])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.maximum(x, A) <= y, y == 2])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.maximum(x + A, A) <= 2])
+    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.maximum(x, z, 1) <= 2, z == 1])
 
     reset_id_counter()
     x = cp.Variable((2, 2), name="X")
@@ -377,6 +380,7 @@ def genexpr_minimum_maximum() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(x, A) >= -y, y == 2])
     yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(A, B) >= -2, x == 1])
     yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(x + A, A) >= -2])
+    yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.minimum(x, z, 1) >= 0, z == 1])
 
     reset_id_counter()
 
@@ -387,6 +391,7 @@ def genexpr_minimum_maximum() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.maximum(x, A) <= y, y == 4])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.maximum(A, B) <= 4, x == 1])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.maximum(x + A, A) <= 4])
+    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.maximum(x, z, 1) <= 2, z == 1])
 
 
 def _genexpr_norm_problems(


### PR DESCRIPTION
Fixes #46. From what I could tell, arguments must either have the same shape or be scalars, there is no complex broadcasting happening in the `cvxpy` atoms.