### PR TITLE
Add support for `quad_form`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Newly supported atoms
+
+- `cp.quad_form` expressions are handled, both when the vector is a variable
+  and when the PSD matrix is a variable (#60).
+
 ## [1.0.0] - 2024-09-28
 
 ### Newly supported atoms

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -454,6 +454,12 @@ class Translater:
         # FIXME: should we do something here?
         return self.visit(node.args[0])
 
+    def visit_QuadForm(self, node: cp.QuadForm) -> Any:
+        vec, psd_mat = node.args
+        vec = self.visit(vec)
+        psd_mat = self.visit(psd_mat)
+        return vec @ psd_mat @ vec
+
     def visit_quad_over_lin(self, node: quad_over_lin) -> Any:
         x, y = node.args
         x = self.visit(x)

--- a/tests/snapshots/all__lp_quad_form0__0.txt
+++ b/tests/snapshots/all__lp_quad_form0__0.txt
@@ -1,0 +1,23 @@
+CVXPY
+Minimize
+  QuadForm(x, [[1.]])
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ [ 2 C0 ^2 ] / 2 
+Subject To
+Bounds
+ C0 free
+End
+----------------------------------------
+GUROBI
+Minimize
+ [ 2 x[0] ^2 ] / 2 
+Subject To
+Bounds
+ x[0] free
+End

--- a/tests/snapshots/all__lp_quad_form1__0.txt
+++ b/tests/snapshots/all__lp_quad_form1__0.txt
@@ -1,0 +1,26 @@
+CVXPY
+Minimize
+  QuadForm(x, [[4.00 6.00]
+ [6.00 10.00]])
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ [ 8 C0 ^2 + 24 C0 * C1 + 20 C1 ^2 ] / 2 
+Subject To
+Bounds
+ C0 free
+ C1 free
+End
+----------------------------------------
+GUROBI
+Minimize
+ [ 8 x[0] ^2 + 24 x[0] * x[1] + 20 x[1] ^2 ] / 2 
+Subject To
+Bounds
+ x[0] free
+ x[1] free
+End

--- a/tests/snapshots/all__lp_quad_form2__0.txt
+++ b/tests/snapshots/all__lp_quad_form2__0.txt
@@ -1,0 +1,37 @@
+CVXPY
+Minimize
+  QuadForm(Hstack(x, [1. 2.]), [[1.00 0.00 0.00 0.00]
+ [0.00 1.00 0.00 0.00]
+ [0.00 0.00 1.00 0.00]
+ [0.00 0.00 0.00 1.00]])
+Subject To
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+ [ 2 C0 ^2 + 2 C1 ^2 + 2 C2 ^2 + 2 C3 ^2 ] / 2 
+Subject To
+ R0: - C0 + C4 = 0
+ R1: - C1 + C5 = 0
+ R2: - C2 = -1
+ R3: - C3 = -2
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+ C4 free
+ C5 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  + 5 Constant + [ 2 x[0] ^2 + 2 x[1] ^2 ] / 2 
+Subject To
+Bounds
+ x[0] free
+ x[1] free
+ Constant = 1
+End

--- a/tests/snapshots/all__lp_quad_form3__0.txt
+++ b/tests/snapshots/all__lp_quad_form3__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  [1. 2.] @ A @ [1. 2.]
+Subject To
+Bounds
+ 0.0 <= A
+End
+----------------------------------------
+AFTER COMPILATION
+Minimize
+  C0 + 2 C1 + 2 C2 + 4 C3
+Subject To
+ R0: - C0 <= 0
+ R1: - C1 <= 0
+ R2: - C2 <= 0
+ R3: - C3 <= 0
+Bounds
+ C0 free
+ C1 free
+ C2 free
+ C3 free
+End
+----------------------------------------
+GUROBI
+Minimize
+  A[0,0] + 2 A[0,1] + 2 A[1,0] + 4 A[1,1]
+Subject To
+Bounds
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -49,6 +49,7 @@ def all_problems() -> Generator[ProblemTestCase, None, None]:
         quadratic_expressions,
         matrix_constraints,
         matrix_quadratic_expressions,
+        quad_form,
         genexpr_abs,
         genexpr_min_max,
         genexpr_minimum_maximum,
@@ -182,6 +183,25 @@ def matrix_quadratic_expressions() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum_squares(x)), [cp.sum_squares(x) <= 1])
     yield cp.Problem(cp.Minimize(cp.sum_squares(A @ x)))
     yield cp.Problem(cp.Minimize(cp.sum_squares(S @ x)))
+
+
+@group_cases("quad_form")
+def quad_form() -> Iterator[cp.Problem]:
+    x = cp.Variable((1,), name="x")
+    A = np.array([[1]])
+    yield cp.Problem(cp.Minimize(cp.quad_form(x, A)))
+
+    x = cp.Variable(2, name="x")
+    y = np.array([1, 2])
+    _A = np.arange(4).reshape((2, 2))
+    A = _A.T @ _A
+    yield cp.Problem(cp.Minimize(cp.quad_form(x, A)))
+    yield cp.Problem(cp.Minimize(cp.quad_form(cp.hstack([x, y]), np.eye(4))))
+
+    x = np.arange(1, 3)
+    # Can't constrain to PSD=True because Gurobi does not solve PSD problems
+    A = cp.Variable((2, 2), name="A", nonneg=True)
+    yield cp.Problem(cp.Minimize(cp.quad_form(x, A)))
 
 
 @group_cases("genexpr_abs")

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -196,7 +196,8 @@ def quad_form() -> Iterator[cp.Problem]:
     _A = np.arange(4).reshape((2, 2))
     A = _A.T @ _A
     yield cp.Problem(cp.Minimize(cp.quad_form(x, A)))
-    yield cp.Problem(cp.Minimize(cp.quad_form(cp.hstack([x, y]), np.eye(4))))
+    if GUROBIPY_VERSION >= (11,):
+        yield cp.Problem(cp.Minimize(cp.quad_form(cp.hstack([x, y]), np.eye(4))))
 
     x = np.arange(1, 3)
     # Can't constrain to PSD=True because Gurobi does not solve PSD problems


### PR DESCRIPTION
Resolves #33.

Nothing special, it just works. Note that I didn't test with complex-valued variables, but I'm not sure Gurobi handles them anyway.