### PR TITLE
Avoid testing on `gurobipy` 10 since the license expired

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,10 @@ env-vars = { UV_RESOLUTION = "lowest-direct" }
 python = "3.8"
 extra-dependencies = [
   # we have to set a version here since cvxpy is not listed as a dependency
-  # note that we don't use cvxpy-base because it was added in 1.1.16
-  "cvxpy>=1.1.2",
+  # we use cvxpy-base to avoid installing unnecessary dependencies
+  "cvxpy-base>=1.2.0",
   # bundled license is expired on older versions of gurobipy
-  "gurobipy>=10",
+  "gurobipy>=11",
 ]
 
 [tool.hatch.envs.hatch-test]


### PR DESCRIPTION
It expired on 2024-10-28, so none of the tests are passing with that version.

Bumping to v11 unearth another issue with `vstack` (which is skipped on older versions of `gurobipy`), this time related to the version of `cvxpy` used in the _oldest_ tests. So I also bumped the minimum tested version of `cvxpy` to 1.2.0 (which released cvxpy/cvxpy#1339), and switched to `cvxpy-base`.

The testing scope of `gurobipy` is now limited to v11, but v12 should be out _soon_ anyway so it won't be the newest version anymore.