### PR TITLE
Add support for `cp.exp` through non-linear expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New
+
+- Add support for `cp.exp` through the non-linear expressions added in Gurobi 12
+  ([#86](https://github.com/jonathanberthias/cvxpy-gurobi/pull/86))
+
 ## [1.1.1] - 2025-02-01
 
 This small release fixes a bug with manually set parameter values and adds

--- a/README.md
+++ b/README.md
@@ -65,16 +65,19 @@ pre-compiled by CVXPY, meaning the model is not exactly the same as the one you
 have written. This is great for solvers with low-level APIs, such as SCS or
 OSQP, but `gurobipy` allows you to express your models at a higher-level.
 
-Providing the raw model to Gurobi is a better idea in general since the Gurobi
-solver is able to compile the problem with a better accuracy. The chosen
-algorithm can also be different depending on the way it is modelled, potentially
-leading to better performance.
+Providing the raw model to Gurobi can be a better idea in general to let the
+Gurobi solver use its own heuristics. The chosen algorithm can be different
+depending on the way it is modelled, potentially leading to better performance.
 
 In addition, CVXPY does not give access to the model before solving it. CVXPY
 must therefore make some choices for you, such as setting `QCPDual` to 1 on all
 non-MIP models. Having access to the model can help if you want to handle the
 call to `.optimize()` in a non-standard way, e.g. by sending it to an async
 loop.
+
+Another feature is the ability to use the latest features of Gurobi, such as
+non-linear expressions, which are not yet supported by the Gurobi interface in
+CVXPY.
 
 ### Example
 

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
 CVXPY_VERSION = tuple(map(int, cp.__version__.split(".")))
 GUROBIPY_VERSION = gp.gurobi.version()
+GUROBI_MAJOR = GUROBIPY_VERSION[0]
 
 AnyVar: TypeAlias = Union[gp.Var, gp.MVar]
 Param: TypeAlias = Union[str, float]
@@ -342,6 +343,13 @@ class Translater:
         left = self.visit(left)
         right = self.visit(right)
         return left == right
+
+    def visit_exp(self, node: cp.exp):
+        (arg,) = node.args
+        expr = self.visit(arg)
+        return self.make_auxilliary_variable_for(
+            gp.nlfunc.exp(expr), "exp", desired_shape=_shape(expr)
+        )
 
     def _stack(self, node: Hstack | Vstack, gp_fn: Callable) -> Any:
         args = node.args

--- a/tests/snapshots/all__lp_nonlinear_exp0__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp0__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Minimize
+  exp(x)
+Subject To
+ 5: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  exp_1
+Subject To
+ 5: x >= 1
+Bounds
+ x free
+ exp_1 free
+General Constraints
+\ exp_1 = exp(x)
+ GC0: exp_1 = NL : ( EXP , -1 , -1 ) ( VARIABLE , x , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp1__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp1__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Minimize
+  exp(x + 1.0)
+Subject To
+ 11: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  exp_1
+Subject To
+ 11: x >= 1
+Bounds
+ x free
+ exp_1 free
+General Constraints
+\ exp_1 = exp(1 + x)
+ GC0: exp_1 = NL : ( EXP , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 1 , 1 ) ( VARIABLE , x , 1 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp2__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp2__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 16: exp(x) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  x
+Subject To
+ 16: exp_1 <= 1
+Bounds
+ x free
+ exp_1 free
+General Constraints
+\ exp_1 = exp(x)
+ GC0: exp_1 = NL : ( EXP , -1 , -1 ) ( VARIABLE , x , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp3__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp3__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Minimize
+  exp(x)
+Subject To
+ 5: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  exp_1[0]
+Subject To
+ 5[0]: x[0] >= 1
+Bounds
+ x[0] free
+ exp_1[0] free
+General Constraints
+\ exp_1[0] = exp(x[0])
+ GC0: exp_1[0] = NL : ( EXP , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp4__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp4__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Minimize
+  exp(x + 1.0)
+Subject To
+ 11: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  exp_1[0]
+Subject To
+ 11[0]: x[0] >= 1
+Bounds
+ x[0] free
+ exp_1[0] free
+General Constraints
+\ exp_1[0] = exp(1 + x[0])
+ GC0: exp_1[0] = NL : ( EXP , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 1 , 1 ) ( VARIABLE , x[0] , 1 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp5__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp5__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Maximize
+  x
+Subject To
+ 16: exp(x) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  x[0]
+Subject To
+ 16[0]: exp_1[0] <= 1
+Bounds
+ x[0] free
+ exp_1[0] free
+General Constraints
+\ exp_1[0] = exp(x[0])
+ GC0: exp_1[0] = NL : ( EXP , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp6__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp6__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(exp(x), None, False)
+Subject To
+ 7: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  exp_1[0] + exp_1[1]
+Subject To
+ 7[0]: x[0] >= 1
+ 7[1]: x[1] >= 1
+Bounds
+ x[0] free
+ x[1] free
+ exp_1[0] free
+ exp_1[1] free
+General Constraints
+\ exp_1[0] = exp(x[0])
+ GC0: exp_1[0] = NL : ( EXP , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+\ exp_1[1] = exp(x[1])
+ GC1: exp_1[1] = NL : ( EXP , -1 , -1 ) ( VARIABLE , x[1] , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp7__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp7__0.txt
@@ -1,0 +1,31 @@
+CVXPY
+Minimize
+  Sum(exp(x + [1. 2.]), None, False)
+Subject To
+ 15: 1.0 <= x
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  exp_1[0] + exp_1[1]
+Subject To
+ 15[0]: x[0] >= 1
+ 15[1]: x[1] >= 1
+Bounds
+ x[0] free
+ x[1] free
+ exp_1[0] free
+ exp_1[1] free
+General Constraints
+\ exp_1[0] = exp(1 + x[0])
+ GC0: exp_1[0] = NL : ( EXP , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 1 , 1 ) ( VARIABLE , x[0] , 1 )
+\ exp_1[1] = exp(2 + x[1])
+ GC1: exp_1[1] = NL : ( EXP , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 2 , 1 ) ( VARIABLE , x[1] , 1 )
+End

--- a/tests/snapshots/all__lp_nonlinear_exp8__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_exp8__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Maximize
+  Sum(x, None, False)
+Subject To
+ 22: exp(x) <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  x[0] + x[1]
+Subject To
+ 22[0]: exp_1[0] <= 1
+ 22[1]: exp_1[1] <= 1
+Bounds
+ x[0] free
+ x[1] free
+ exp_1[0] free
+ exp_1[1] free
+General Constraints
+\ exp_1[0] = exp(x[0])
+ GC0: exp_1[0] = NL : ( EXP , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+\ exp_1[1] = exp(x[1])
+ GC1: exp_1[1] = NL : ( EXP , -1 , -1 ) ( VARIABLE , x[1] , 0 )
+End


### PR DESCRIPTION
This is the first feature the cvxpy interface doesn't support, even though it can be expressed in cvxpy's DSL!