### PR TITLE
Add support for `log` and `log1p`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New
 
-- Add support for `cp.exp` through the non-linear expressions added in Gurobi 12
+- Add support for `cp.exp`, `cp.log` and `cp.log1p` through the non-linear expressions added in Gurobi 12
   ([#86](https://github.com/jonathanberthias/cvxpy-gurobi/pull/86))
 
 ## [1.1.1] - 2025-02-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### New
 
-- Add support for `cp.exp`, `cp.log` and `cp.log1p` through the non-linear expressions added in Gurobi 12 ([#86](https://github.com/jonathanberthias/cvxpy-gurobi/pull/86), [#87](https://github.com/jonathanberthias/cvxpy-gurobi/pull/87))
+- Add support for `cp.exp`, `cp.log` and `cp.log1p` through the non-linear
+  expressions added in Gurobi 12
+  ([#86](https://github.com/jonathanberthias/cvxpy-gurobi/pull/86),
+  [#87](https://github.com/jonathanberthias/cvxpy-gurobi/pull/87))
 
 ## [1.1.1] - 2025-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New
 
-- Add support for `cp.exp`, `cp.log` and `cp.log1p` through the non-linear expressions added in Gurobi 12
+- Add support for `cp.exp`, `cp.log` and `cp.log1p` through the non-linear
+  expressions added in Gurobi 12
   ([#86](https://github.com/jonathanberthias/cvxpy-gurobi/pull/86))
 
 ## [1.1.1] - 2025-02-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### New
 
-- Add support for `cp.exp`, `cp.log` and `cp.log1p` through the non-linear
-  expressions added in Gurobi 12
-  ([#86](https://github.com/jonathanberthias/cvxpy-gurobi/pull/86))
+- Add support for `cp.exp`, `cp.log` and `cp.log1p` through the non-linear expressions added in Gurobi 12 ([#86](https://github.com/jonathanberthias/cvxpy-gurobi/pull/86), [#87](https://github.com/jonathanberthias/cvxpy-gurobi/pull/87))
 
 ## [1.1.1] - 2025-02-01
 

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -82,7 +82,7 @@ class InvalidNormError(UnsupportedExpressionError):
     )
 
 
-class InvalidNonlinearAtom(UnsupportedExpressionError):
+class InvalidNonlinearAtomError(UnsupportedExpressionError):
     msg_template = "Unsupported nonlinear atom: {node}, upgrade your version of gurobipy"
 
 
@@ -350,7 +350,7 @@ class Translater:
 
     def visit_exp(self, node: cp.exp) -> AnyVar:
         if GUROBI_MAJOR < 12:
-            raise InvalidNonlinearAtom(node)
+            raise InvalidNonlinearAtomError(node)
         (arg,) = node.args
         expr = self.visit(arg)
         return self.make_auxilliary_variable_for(
@@ -382,7 +382,7 @@ class Translater:
 
     def visit_log(self, node: cp.log) -> AnyVar:
         if GUROBI_MAJOR < 12:
-            raise InvalidNonlinearAtom(node)
+            raise InvalidNonlinearAtomError(node)
         (arg,) = node.args
         expr = self.visit(arg)
         return self.make_auxilliary_variable_for(
@@ -391,7 +391,7 @@ class Translater:
 
     def visit_log1p(self, node: cp.log1p) -> AnyVar:
         if GUROBI_MAJOR < 12:
-            raise InvalidNonlinearAtom(node)
+            raise InvalidNonlinearAtomError(node)
         (arg,) = node.args
         expr = self.visit(arg)
         return self.make_auxilliary_variable_for(

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -15,6 +15,7 @@ import cvxpy as cp
 import gurobipy as gp
 import numpy as np
 import numpy.typing as npt
+from gurobipy import nlfunc
 
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -348,7 +349,7 @@ class Translater:
         (arg,) = node.args
         expr = self.visit(arg)
         return self.make_auxilliary_variable_for(
-            gp.nlfunc.exp(expr), "exp", desired_shape=_shape(expr)
+            nlfunc.exp(expr), "exp", desired_shape=_shape(expr)
         )
 
     def _stack(self, node: Hstack | Vstack, gp_fn: Callable) -> Any:
@@ -372,6 +373,20 @@ class Translater:
             upper >= lower
             if _should_reverse_inequality(lower, upper)
             else lower <= upper
+        )
+
+    def visit_log(self, node: cp.log) -> Any:
+        (arg,) = node.args
+        expr = self.visit(arg)
+        return self.make_auxilliary_variable_for(
+            nlfunc.log(expr), "log", desired_shape=_shape(expr)
+        )
+
+    def visit_log1p(self, node: cp.log1p) -> Any:
+        (arg,) = node.args
+        expr = self.visit(arg)
+        return self.make_auxilliary_variable_for(
+            nlfunc.log(expr + 1), "log1p", desired_shape=_shape(expr)
         )
 
     def _min_max(

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -83,7 +83,9 @@ class InvalidNormError(UnsupportedExpressionError):
 
 
 class InvalidNonlinearAtomError(UnsupportedExpressionError):
-    msg_template = "Unsupported nonlinear atom: {node}, upgrade your version of gurobipy"
+    msg_template = (
+        "Unsupported nonlinear atom: {node}, upgrade your version of gurobipy"
+    )
 
 
 class InvalidParameterError(UnsupportedExpressionError):

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -348,7 +348,7 @@ class Translater:
         right = self.visit(right)
         return left == right
 
-    def visit_exp(self, node: cp.exp):
+    def visit_exp(self, node: cp.exp) -> AnyVar:
         if GUROBI_MAJOR < 12:
             raise InvalidNonlinearAtom(node)
         (arg,) = node.args
@@ -380,7 +380,7 @@ class Translater:
             else lower <= upper
         )
 
-    def visit_log(self, node: cp.log) -> Any:
+    def visit_log(self, node: cp.log) -> AnyVar:
         if GUROBI_MAJOR < 12:
             raise InvalidNonlinearAtom(node)
         (arg,) = node.args
@@ -389,7 +389,7 @@ class Translater:
             gp.nlfunc.log(expr), "log", desired_shape=_shape(expr)
         )
 
-    def visit_log1p(self, node: cp.log1p) -> Any:
+    def visit_log1p(self, node: cp.log1p) -> AnyVar:
         if GUROBI_MAJOR < 12:
             raise InvalidNonlinearAtom(node)
         (arg,) = node.args

--- a/tests/snapshots/all__lp_nonlinear_log0__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log0__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Maximize
+  log(x)
+Subject To
+ 5: x <= 2.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  log_1
+Subject To
+ 5: x <= 2
+Bounds
+ x free
+ log_1 free
+General Constraints
+\ log_1 = log(x)
+ GC0: log_1 = NL : ( LOG , -1 , -1 ) ( VARIABLE , x , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log1__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log1__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Maximize
+  log1p(x)
+Subject To
+ 10: x <= 2.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  log1p_1
+Subject To
+ 10: x <= 2
+Bounds
+ x free
+ log1p_1 free
+General Constraints
+\ log1p_1 = log(1 + x)
+ GC0: log1p_1 = NL : ( LOG , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 1 , 1 ) ( VARIABLE , x , 1 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log2__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log2__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 15: -1.0 <= log(x)
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  x
+Subject To
+ 15: log_1 >= -1
+Bounds
+ x free
+ log_1 free
+General Constraints
+\ log_1 = log(x)
+ GC0: log_1 = NL : ( LOG , -1 , -1 ) ( VARIABLE , x , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log3__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log3__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Maximize
+  log(x)
+Subject To
+ 5: x <= 0.5
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  log_1[0]
+Subject To
+ 5[0]: x[0] <= 0.5
+Bounds
+ x[0] free
+ log_1[0] free
+General Constraints
+\ log_1[0] = log(x[0])
+ GC0: log_1[0] = NL : ( LOG , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log4__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log4__0.txt
@@ -1,0 +1,25 @@
+CVXPY
+Maximize
+  log1p(x + 1.0)
+Subject To
+ 11: x <= -0.5
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  log1p_1[0]
+Subject To
+ 11[0]: x[0] <= -0.5
+Bounds
+ x[0] free
+ log1p_1[0] free
+General Constraints
+\ log1p_1[0] = log(2 + x[0])
+ GC0: log1p_1[0] = NL : ( LOG , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 2 , 1 ) ( VARIABLE , x[0] , 1 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log5__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log5__0.txt
@@ -1,0 +1,24 @@
+CVXPY
+Minimize
+  x
+Subject To
+ 16: 1.0 <= log(x)
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  x[0]
+Subject To
+ 16[0]: log_1[0] >= 1
+Bounds
+ x[0] free
+ log_1[0] free
+General Constraints
+\ log_1[0] = log(x[0])
+ GC0: log_1[0] = NL : ( LOG , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log6__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log6__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Maximize
+  Sum(log(x), None, False)
+Subject To
+ 7: x <= 1.0
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  log_1[0] + log_1[1]
+Subject To
+ 7[0]: x[0] <= 1
+ 7[1]: x[1] <= 1
+Bounds
+ x[0] free
+ x[1] free
+ log_1[0] free
+ log_1[1] free
+General Constraints
+\ log_1[0] = log(x[0])
+ GC0: log_1[0] = NL : ( LOG , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+\ log_1[1] = log(x[1])
+ GC1: log_1[1] = NL : ( LOG , -1 , -1 ) ( VARIABLE , x[1] , 0 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log7__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log7__0.txt
@@ -1,0 +1,31 @@
+CVXPY
+Maximize
+  Sum(log1p(x), None, False)
+Subject To
+ 14: x <= -0.5
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Maximize
+  log1p_1[0] + log1p_1[1]
+Subject To
+ 14[0]: x[0] <= -0.5
+ 14[1]: x[1] <= -0.5
+Bounds
+ x[0] free
+ x[1] free
+ log1p_1[0] free
+ log1p_1[1] free
+General Constraints
+\ log1p_1[0] = log(1 + x[0])
+ GC0: log1p_1[0] = NL : ( LOG , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 1 , 1 ) ( VARIABLE , x[0] , 1 )
+\ log1p_1[1] = log(1 + x[1])
+ GC1: log1p_1[1] = NL : ( LOG , -1 , -1 ) ( PLUS , -1 , 0 ) 
+  ( CONSTANT , 1 , 1 ) ( VARIABLE , x[1] , 1 )
+End

--- a/tests/snapshots/all__lp_nonlinear_log8__0.txt
+++ b/tests/snapshots/all__lp_nonlinear_log8__0.txt
@@ -1,0 +1,29 @@
+CVXPY
+Minimize
+  Sum(x, None, False)
+Subject To
+ 21: 1.0 <= log(x)
+Bounds
+ x free
+End
+----------------------------------------
+AFTER COMPILATION
+Either candidate conic solvers (['GUROBI']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
+----------------------------------------
+GUROBI
+Minimize
+  x[0] + x[1]
+Subject To
+ 21[0]: log_1[0] >= 1
+ 21[1]: log_1[1] >= 1
+Bounds
+ x[0] free
+ x[1] free
+ log_1[0] free
+ log_1[1] free
+General Constraints
+\ log_1[0] = log(x[0])
+ GC0: log_1[0] = NL : ( LOG , -1 , -1 ) ( VARIABLE , x[0] , 0 )
+\ log_1[1] = log(x[1])
+ GC1: log_1[1] = NL : ( LOG , -1 , -1 ) ( VARIABLE , x[1] , 0 )
+End

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -65,6 +65,7 @@ def all_problems() -> Generator[ProblemTestCase, None, None]:
         hstack,
         vstack,
         nonlinear_exp,
+        nonlinear_log,
         attributes,
         invalid_expressions,
     ):
@@ -660,6 +661,26 @@ def nonlinear_exp() -> Iterator[cp.Problem]:
     yield cp.Problem(cp.Minimize(cp.sum(cp.exp(x))), [x >= 1])
     yield cp.Problem(cp.Minimize(cp.sum(cp.exp(x + t))), [x >= 1])
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.exp(x) <= 1])
+
+
+@group_cases("nonlinear_log", available=GUROBI_MAJOR >= 12)
+def nonlinear_log() -> Iterator[cp.Problem]:
+    x = cp.Variable(name="x")
+    yield cp.Problem(cp.Maximize(cp.log(x)), [x <= 2])
+    yield cp.Problem(cp.Maximize(cp.log1p(x)), [x <= 2])
+    yield cp.Problem(cp.Minimize(x), [cp.log(x) >= -1])
+
+    reset_id_counter()
+    x = cp.Variable(1, name="x")
+    yield cp.Problem(cp.Maximize(cp.log(x)), [x <= 0.5])
+    yield cp.Problem(cp.Maximize(cp.log1p(x + 1)), [x <= -0.5])
+    yield cp.Problem(cp.Minimize(x), [cp.log(x) >= 1])
+
+    reset_id_counter()
+    x = cp.Variable(2, name="x")
+    yield cp.Problem(cp.Maximize(cp.sum(cp.log(x))), [x <= 1])
+    yield cp.Problem(cp.Maximize(cp.sum(cp.log1p(x))), [x <= -0.5])
+    yield cp.Problem(cp.Minimize(cp.sum(x)), [cp.log(x) >= 1])
 
 
 @group_cases("attributes")


### PR DESCRIPTION
Exactly the same as for `exp`.

Closes #83 