### PR TITLE
Retrieve cvxpy version from metadata

### DIFF
--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
     from cvxpy.utilities.canonical import Canonical
 
 
-CVXPY_VERSION: tuple[int]
 try:
     CVXPY_VERSION = tuple(map(int, importlib.metadata.version("cvxpy").split(".")))
 except importlib.metadata.PackageNotFoundError:

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import operator
 from functools import reduce
 from math import prod
@@ -47,7 +48,11 @@ if TYPE_CHECKING:
     from cvxpy.utilities.canonical import Canonical
 
 
-CVXPY_VERSION = tuple(map(int, cp.__version__.split(".")))
+CVXPY_VERSION: tuple[int]
+try:
+    CVXPY_VERSION = tuple(map(int, importlib.metadata.version("cvxpy").split(".")))
+except importlib.metadata.PackageNotFoundError:
+    CVXPY_VERSION = tuple(map(int, importlib.metadata.version("cvxpy-base").split(".")))
 GUROBIPY_VERSION = gp.gurobi.version()
 GUROBI_MAJOR = GUROBIPY_VERSION[0]
 


### PR DESCRIPTION
The `__version__` attribute is broken on 1.6.1. The version in the metadata is more reliable, though we have to check both `cvxpy` and `cvxpy-base` now...