### PR TITLE
Specify order for reshape atom

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,5 +8,5 @@ repos:
     rev: v0.11.13
     hooks:
       - id: ruff
-        args: [--fix]
+        args: [--fix, "--show-fixes"]
       - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.8",
@@ -97,34 +96,6 @@ extra-dependencies = [
   "gurobipy>=11",
 ]
 
-[tool.hatch.envs.hatch-test]
-extra-dependencies = [
-  "cvxpy-base=={matrix:cvxpy}.*",
-  "gurobipy=={matrix:gurobipy}.*",
-  "numpy{matrix:numpy:}",
-  "scipy{matrix:scipy:}",
-  "pytest-insta",
-]
-matrix-name-format = "{variable}{value}"
-
-[[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.8"]
-gurobipy = ["10"]
-cvxpy = ["1.3"]
-numpy = ["<2"]
-scipy = ["<1.14"] # cvxpy 1.3 uses scipy features (.A) removed in 1.14
-
-[[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.9"]
-gurobipy = ["11"]
-cvxpy = ["1.4"]
-numpy = ["<2"]
-
-[[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12"]
-gurobipy = ["11"]
-cvxpy = ["1.5"]
-
 [tool.hatch.envs.types]
 description = "Type checking environment"
 template = "latest"
@@ -199,7 +170,11 @@ max-args = 10
 skip-magic-trailing-comma = true
 
 [tool.pytest.ini_options]
+addopts = ["-ra", "--strict-config", "--strict-markers"]
+minversion = "6"
 pythonpath = "tests"
+testpaths = ["tests"]
+xfail_strict = true
 
 [tool.coverage.run]
 source_pkgs = ["cvxpy_gurobi"]

--- a/src/cvxpy_gurobi/interface.py
+++ b/src/cvxpy_gurobi/interface.py
@@ -219,7 +219,7 @@ def get_constraint_by_name(model: gp.Model, name: str) -> gp.Constr | gp.QConstr
         for q_constr in model.getQConstrs():
             if q_constr.QCName == name:
                 return q_constr
-        raise
+        raise  # pragme: no cover
     else:
         assert constr is not None
         return constr

--- a/src/cvxpy_gurobi/translation.py
+++ b/src/cvxpy_gurobi/translation.py
@@ -143,7 +143,7 @@ def promote_array_to_gurobi_matrixapi(array: npt.NDArray[np.object_]) -> Any:
         return gp.MVar.fromlist(array)
     # TODO: support other types
     msg = f"Cannot promote array of {kind}"
-    raise NotImplementedError(msg)
+    raise NotImplementedError(msg)  # pragma: no cover
 
 
 def translate_variable(var: cp.Variable, model: gp.Model) -> AnyVar:

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -534,54 +534,87 @@ def sum_axis() -> Iterator[cp.Problem]:
 def reshape() -> Iterator[cp.Problem]:
     x = cp.Variable(name="x")
     a = x + 1
-    yield cp.Problem(cp.Maximize(x), [cp.reshape(x, ()) <= 1])
-    yield cp.Problem(cp.Maximize(x), [cp.reshape(x, 1) <= np.ones(1)])
+    yield cp.Problem(cp.Maximize(x), [cp.reshape(x, (), order="F") <= 1])
+    yield cp.Problem(cp.Maximize(x), [cp.reshape(x, 1, order="F") <= np.ones(1)])
     if CVXPY_VERSION >= (1, 4, 0):
         # -1 support added in https://github.com/cvxpy/cvxpy/pull/2061
-        yield cp.Problem(cp.Maximize(x), [cp.reshape(x, -1) <= np.ones(1)])
-    yield cp.Problem(cp.Maximize(x), [cp.reshape(a, ()) <= 1])
-    yield cp.Problem(cp.Maximize(x), [cp.reshape(a, (1,)) <= np.ones(1)])
+        yield cp.Problem(cp.Maximize(x), [cp.reshape(x, -1, order="F") <= np.ones(1)])
+    yield cp.Problem(cp.Maximize(x), [cp.reshape(a, (), order="F") <= 1])
+    yield cp.Problem(cp.Maximize(x), [cp.reshape(a, (1,), order="F") <= np.ones(1)])
     if CVXPY_VERSION >= (1, 4, 0):
-        yield cp.Problem(cp.Maximize(x), [cp.reshape(a, -1) <= np.ones(1)])
+        yield cp.Problem(cp.Maximize(x), [cp.reshape(a, -1, order="F") <= np.ones(1)])
 
     yield cp.Problem(cp.Maximize(x), [cp.vec(x) <= np.ones(1)])
 
     reset_id_counter()
     x = cp.Variable(1, name="x")
     a = x + 1
-    yield cp.Problem(cp.Maximize(x), [cp.reshape(x, ()) <= 1])
-    yield cp.Problem(cp.Maximize(x), [cp.reshape(a, ()) <= 1])
+    yield cp.Problem(cp.Maximize(x), [cp.reshape(x, (), order="F") <= 1])
+    yield cp.Problem(cp.Maximize(x), [cp.reshape(a, (), order="F") <= 1])
     yield cp.Problem(cp.Maximize(x), [cp.vec(x) <= np.ones(1)])
 
     reset_id_counter()
     x = cp.Variable(2, name="x")
     a = x + np.array([1, 1])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (2,)) <= np.ones(2)])
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (2,), order="F") <= np.ones(2)]
+    )
     if CVXPY_VERSION >= (1, 4, 0):
-        yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, -1) <= np.ones(2)])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (2, 1)) <= np.ones((2, 1))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (1, 2)) <= np.ones((1, 2))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (2,)) <= np.ones(2)])
+        yield cp.Problem(
+            cp.Maximize(cp.sum(x)), [cp.reshape(x, -1, order="F") <= np.ones(2)]
+        )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (2, 1), order="F") <= np.ones((2, 1))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (1, 2), order="F") <= np.ones((1, 2))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(a, (2,), order="F") <= np.ones(2)]
+    )
     if CVXPY_VERSION >= (1, 4, 0):
-        yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (-1,)) <= np.ones(2)])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (2, 1)) <= np.ones((2, 1))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (1, 2)) <= np.ones((1, 2))])
+        yield cp.Problem(
+            cp.Maximize(cp.sum(x)), [cp.reshape(a, (-1,), order="F") <= np.ones(2)]
+        )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(a, (2, 1), order="F") <= np.ones((2, 1))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(a, (1, 2), order="F") <= np.ones((1, 2))]
+    )
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.vec(x) <= np.arange(2)])
 
     reset_id_counter()
     x = cp.Variable(4, name="x")
     c = np.ones(4)
     a = x + c
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (4,)) <= np.ones(4)])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (4, 1)) <= np.ones((4, 1))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (2, 2)) <= np.ones((2, 2))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(x, (1, 4)) <= np.ones((1, 4))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (4,)) <= np.ones(4)])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (4, 1)) <= np.ones((4, 1))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (2, 2)) <= np.ones((2, 2))])
-    yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.reshape(a, (1, 4)) <= np.ones((1, 4))])
     yield cp.Problem(
-        cp.Maximize(cp.sum(x)), [cp.reshape(x, (2, 2)) <= cp.reshape(c, (2, 2))]
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (4,), order="F") <= np.ones(4)]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (4, 1), order="F") <= np.ones((4, 1))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (2, 2), order="F") <= np.ones((2, 2))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(x, (1, 4), order="F") <= np.ones((1, 4))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(a, (4,), order="F") <= np.ones(4)]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(a, (4, 1), order="F") <= np.ones((4, 1))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(a, (2, 2), order="F") <= np.ones((2, 2))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)), [cp.reshape(a, (1, 4), order="F") <= np.ones((1, 4))]
+    )
+    yield cp.Problem(
+        cp.Maximize(cp.sum(x)),
+        [cp.reshape(x, (2, 2), order="F") <= cp.reshape(c, (2, 2), order="F")],
     )
     yield cp.Problem(cp.Maximize(cp.sum(x)), [cp.vec(x) <= np.arange(4)])
 


### PR DESCRIPTION
There is a warning when it is not given explicitly. There is also one for `vec`, unfortunately the `reshape` argument was added more recently and didn't exist in 1.2.0.

I also did a few cosmetic changes to the pytest configuration. 