### PR TITLE
Use GitHub environments when publishing package

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           # needed to get tags to generate version file
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: hynek/build-and-inspect-python-package@v2
         with:
@@ -37,8 +38,10 @@ jobs:
   test-publish:
     needs: dist
     name: Publish to TestPyPI
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/cvxpy-translation
     permissions:
-      contents: read
       id-token: write
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -56,8 +59,10 @@ jobs:
   publish:
     needs: dist
     name: Publish to PyPI
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cvxpy-translation
     permissions:
-      contents: read
       id-token: write
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
Following this guide: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/