### PR TITLE
Update CVXPY and PySCIPOpt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,9 @@ all-tests = [
 description = "Dependencies at their most up-to-date versions"
 python = "3.13"
 extra-dependencies = [
-  "cvxpy-base==1.7.1",
+  "cvxpy-base==1.7.2",
   "gurobipy==12.0.3",
-  "pyscipopt==5.5.0",
+  "pyscipopt==5.6.0",
   "numpy==2.3.2",
   "scipy==1.16.1",
 ]


### PR DESCRIPTION
Renovate is broken so it doesn't detect Hatch dependencies anymore. In the meantime, manual updates it is.