### PR TITLE
Fix SCIP backfill when constraint removed

### DIFF
--- a/src/cvxpy_translation/scip/interface.py
+++ b/src/cvxpy_translation/scip/interface.py
@@ -192,15 +192,18 @@ def _contains_quad_form(constraint: Constraint) -> bool:
 
 
 def _get_scalar_constraint_dual(model: scip.Model, constraint_name: str) -> float:
-    constr = get_constraint_by_name(model, constraint_name)
-    if constr.getConshdlrName() == "nonlinear":
+    try:
+        constr = get_constraint_by_name(model, constraint_name)
+    except LookupError as e:
+        raise UnavailableDualError from e
+    if constr.isNonlinear():
         # dual solutions are not available for nonlinear constraints
         raise UnavailableDualError
     return model.getDualsolLinear(constr)
 
 
 def get_constraint_by_name(model: scip.Model, name: str) -> scip.Constraint:
-    constrs = model.getConss(transformed=False)
+    constrs = model.getConss(transformed=True)
     for constr in constrs:
         if constr.name == name:
             return constr

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,23 @@
+import cvxpy as cp
+
+from cvxpy_translation import backfill_problem
+from cvxpy_translation import build_model
+
+
+def test_empty_presolved_model_scip():
+    """If presolve removes the constraints, it is impossible to get their dual value."""
+    x = cp.Variable()
+    problem = cp.Problem(cp.Minimize(x), [x >= 0])
+    model = build_model(problem, cp.SCIP)
+    model.optimize()
+    assert model.getNConss(transformed=True) == 0
+    backfill_problem(problem, model)
+
+
+def test_empty_presolved_model_grb():
+    """If presolve removes the constraints, it should still be possible to get their dual value."""
+    x = cp.Variable()
+    problem = cp.Problem(cp.Minimize(x), [x >= 0])
+    model = build_model(problem, cp.GUROBI)
+    model.optimize()
+    backfill_problem(problem, model)


### PR DESCRIPTION
SCIP does not provide duals for constraints that get removed by presolve, unlike Gurobi.

Fixes #198 