### PR TITLE
Use CIP format for SCIP snapshots

### DIFF
--- a/tests/snapshots/scip/attributes_00.txt
+++ b/tests/snapshots/scip/attributes_00.txt
@@ -7,18 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
-Bounds
- -inf <= x <= 0
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,0]
+END

--- a/tests/snapshots/scip/attributes_01.txt
+++ b/tests/snapshots/scip/attributes_01.txt
@@ -7,18 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
-Bounds
- -inf <= x <= 0
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,0]
+END

--- a/tests/snapshots/scip/attributes_02.txt
+++ b/tests/snapshots/scip/attributes_02.txt
@@ -10,23 +10,19 @@ Generals
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-Generals
- x_0
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [integer] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[I] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 n
-Subject to
- 6: +1 n >= +1
-Bounds
- n free
-Generals
- n
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [integer] <n>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <6>: <n>[I] >= 1;
+END

--- a/tests/snapshots/scip/attributes_03.txt
+++ b/tests/snapshots/scip/attributes_03.txt
@@ -8,21 +8,15 @@ Binaries
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
-Bounds
- 0 <= x_0 <= 1
-Binaries
- x_0
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [binary] <x_0>: obj=1, original bounds=[0,1]
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 b
-Subject to
-Bounds
- 0 <= b <= 1
-Binaries
- b
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [binary] <b>: obj=1, original bounds=[0,1]
+END

--- a/tests/snapshots/scip/attributes_04.txt
+++ b/tests/snapshots/scip/attributes_04.txt
@@ -13,32 +13,24 @@ Generals
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_2 -1 x_1 -1 x_0
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +1
-Bounds
- 0 <= x_2 <= 1
- x_1 free
- x_0 free
-Binaries
- x_2
-Generals
- x_1
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [binary] <x_2>: obj=-1, original bounds=[0,1]
+  [integer] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[I] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 b +1 n +1 x
-Subject to
- 13: +1 n <= +1
-Bounds
- 0 <= b <= 1
- n free
- -inf <= x <= 0
-Binaries
- b
-Generals
- n
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [binary] <b>: obj=1, original bounds=[0,1]
+  [integer] <n>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x>: obj=1, original bounds=[-inf,0]
+CONSTRAINTS
+  [linear] <13>: <n>[I] <= 1;
+END

--- a/tests/snapshots/scip/bounds_00.txt
+++ b/tests/snapshots/scip/bounds_00.txt
@@ -8,19 +8,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
- c2: +1 x_0 <= +2
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>: <x_0>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
-Bounds
- 1 <= x <= 2
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[1,2]
+END

--- a/tests/snapshots/scip/bounds_01.txt
+++ b/tests/snapshots/scip/bounds_01.txt
@@ -8,19 +8,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: -1 x_0 <= -1
- c2: +1 x_0 <= +3.5
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>: <x_0>[C] <= 3.5;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
-Bounds
- 1 <= x_0 <= 3.5
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[1,3.5]
+END

--- a/tests/snapshots/scip/bounds_02.txt
+++ b/tests/snapshots/scip/bounds_02.txt
@@ -8,23 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: +1 x_0 <= +3
- c4: +1 x_1 <= +4
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>: <x_0>[C] <= 3;
+  [linear] <c4>: <x_1>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
-Bounds
- 1 <= X_0 <= 3
- 1 <= X_1 <= 4
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[1,3]
+  [continuous] <X_1>: obj=1, original bounds=[1,4]
+END

--- a/tests/snapshots/scip/bounds_03.txt
+++ b/tests/snapshots/scip/bounds_03.txt
@@ -8,31 +8,30 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_2 <= -1
- c3: -1 x_1 <= -2
- c4: -1 x_3 <= -3
- c5: +1 x_0 <= +1
- c6: +1 x_2 <= +2
- c7: +1 x_1 <= +3
- c8: +1 x_3 <= +4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_2>[C] <= -1;
+  [linear] <c3>:  -<x_1>[C] <= -2;
+  [linear] <c4>:  -<x_3>[C] <= -3;
+  [linear] <c5>: <x_0>[C] <= 1;
+  [linear] <c6>: <x_2>[C] <= 2;
+  [linear] <c7>: <x_1>[C] <= 3;
+  [linear] <c8>: <x_3>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
-Bounds
- 0 <= X_0_0 <= 1
- 1 <= X_0_1 <= 2
- 2 <= X_1_0 <= 3
- 3 <= X_1_1 <= 4
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[0,1]
+  [continuous] <X_0_1>: obj=1, original bounds=[1,2]
+  [continuous] <X_1_0>: obj=1, original bounds=[2,3]
+  [continuous] <X_1_1>: obj=1, original bounds=[3,4]
+END

--- a/tests/snapshots/scip/constant_objective_00.txt
+++ b/tests/snapshots/scip/constant_objective_00.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: 0 x_0
-Subject to
- c1: +1 x_0 = -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: 0 x
-Subject to
- 4: +1 x = -1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <4>: <x>[C] == -1;
+END

--- a/tests/snapshots/scip/constant_objective_01.txt
+++ b/tests/snapshots/scip/constant_objective_01.txt
@@ -8,19 +8,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: 0 x_0
-Subject to
- c1: +1 x_0 = +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: -2.5
-Subject to
- 8: +1 x = +0
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+  Offset           : -2.5
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <8>: <x>[C] == 0;
+END

--- a/tests/snapshots/scip/constant_objective_02.txt
+++ b/tests/snapshots/scip/constant_objective_02.txt
@@ -8,19 +8,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: 0 x_0
-Subject to
- c1: +1 x_0 = +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1
-Subject to
- 12: +1 x = +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <12>: <x>[C] == 1;
+END

--- a/tests/snapshots/scip/constant_objective_03.txt
+++ b/tests/snapshots/scip/constant_objective_03.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: 0 x_0
-Subject to
- c1: +1 x_0 = +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: 0 x
-Subject to
- 16: +1 x = +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <16>: <x>[C] == 1;
+END

--- a/tests/snapshots/scip/constant_objective_04.txt
+++ b/tests/snapshots/scip/constant_objective_04.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: 0 x_0
-Subject to
- c1: +1 x_0 = +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: 0 x
-Subject to
- 20: +1 x = +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <20>: <x>[C] == 1;
+END

--- a/tests/snapshots/scip/constant_objective_05.txt
+++ b/tests/snapshots/scip/constant_objective_05.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: 0 x_0
-Subject to
- c1: +1 x_0 = +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: 0 x
-Subject to
- 24: +1 x = +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <24>: <x>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_abs_00.txt
+++ b/tests/snapshots/scip/genexpr_abs_00.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>))+<x2>*(-1) <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_01.txt
+++ b/tests/snapshots/scip/genexpr_abs_01.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>))+<x2>*(-1)+1 <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>))+<x2>*(-1)+1 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_02.txt
+++ b/tests/snapshots/scip/genexpr_abs_02.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 +1 x_2 <= +0
- c2: -1 x_0 -1 x_2 <= +0
- c3: -1 x_1 +1 x_3 <= +0
- c4: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<x>))+abs((<y>))+<x3>*(-1) <= 0;
-Bounds
- x free
- y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>))+abs((<y>))+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_03.txt
+++ b/tests/snapshots/scip/genexpr_abs_03.txt
@@ -8,24 +8,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 +1 x_2 <= +0
- c2: -1 x_0 -1 x_1 -1 x_2 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] -<x_2>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<x>+<y>))+<x3>*(-1) <= 0;
-Bounds
- x free
- y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>+<y>))+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_04.txt
+++ b/tests/snapshots/scip/genexpr_abs_04.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+<x2>*(-1) <= 0;
-Bounds
- X_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_05.txt
+++ b/tests/snapshots/scip/genexpr_abs_05.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+<x2>*(-1)+1 <= 0;
-Bounds
- X_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+<x2>*(-1)+1 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_06.txt
+++ b/tests/snapshots/scip/genexpr_abs_06.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 +1 x_2 <= +0
- c2: -1 x_0 -1 x_2 <= +0
- c3: -1 x_1 +1 x_3 <= +0
- c4: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+abs((<Y>))+<x3>*(-1) <= 0;
-Bounds
- X_0 free
- Y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+abs((<Y>))+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_07.txt
+++ b/tests/snapshots/scip/genexpr_abs_07.txt
@@ -8,24 +8,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 +1 x_2 <= +0
- c2: -1 x_0 -1 x_1 -1 x_2 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] -<x_2>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>+<Y>))+<x3>*(-1) <= 0;
-Bounds
- X_0 free
- Y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>+<Y>))+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_08.txt
+++ b/tests/snapshots/scip/genexpr_abs_08.txt
@@ -7,27 +7,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_2 <= +0
- c2: -1 x_3 <= +0
- c3: -1 x_0 +1 x_2 <= +0
- c4: -1 x_1 +1 x_3 <= +0
- c5: -1 x_0 -1 x_2 <= +0
- c6: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1) <= 0;
-Bounds
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_09.txt
+++ b/tests/snapshots/scip/genexpr_abs_09.txt
@@ -8,31 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_2 <= +0
- c2: -1 x_3 <= +0
- c3: -1 x_4 <= +0
- c4: -1 x_5 <= +0
- c5: -1 x_0 +1 x_2 +1 x_4 <= +0
- c6: -1 x_1 +1 x_3 +1 x_5 <= +0
- c7: -1 x_0 -1 x_2 -1 x_4 <= +0
- c8: -1 x_1 -1 x_3 -1 x_5 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_5>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] +<x_2>[C] +<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] +<x_3>[C] +<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_0>[C] -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c8>:  -<x_1>[C] -<x_3>[C] -<x_5>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>+<Y_0>))+abs((<X_1>+<Y_1>))+<x5>*(-1) <= 0;
-Bounds
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>+<Y_0>))+abs((<X_1>+<Y_1>))+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_10.txt
+++ b/tests/snapshots/scip/genexpr_abs_10.txt
@@ -7,27 +7,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_2 <= +0
- c2: -1 x_3 <= +0
- c3: -1 x_0 +1 x_2 <= +0
- c4: -1 x_1 +1 x_3 <= +0
- c5: -1 x_0 -1 x_2 <= +0
- c6: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1)+2 <= 0;
-Bounds
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1)+2 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_11.txt
+++ b/tests/snapshots/scip/genexpr_abs_11.txt
@@ -7,27 +7,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_2 <= +0
- c2: -1 x_3 <= +0
- c3: -1 x_0 +1 x_2 <= +0
- c4: -1 x_1 +1 x_3 <= +0
- c5: -1 x_0 -1 x_2 <= +0
- c6: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1)+(-1) <= 0;
-Bounds
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1)+(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_12.txt
+++ b/tests/snapshots/scip/genexpr_abs_12.txt
@@ -8,37 +8,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_4 <= +0
- c2: -1 x_5 <= +0
- c3: -1 x_6 <= +0
- c4: -1 x_7 <= +0
- c5: -1 x_0 +1 x_4 <= +0
- c6: -1 x_1 +1 x_5 <= +0
- c7: -1 x_0 -1 x_4 <= +0
- c8: -1 x_1 -1 x_5 <= +0
- c9: -1 x_2 +1 x_6 <= +0
- c10: -1 x_3 +1 x_7 <= +0
- c11: -1 x_2 -1 x_6 <= +0
- c12: -1 x_3 -1 x_7 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] +<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c8>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c9>:  -<x_2>[C] +<x_6>[C] <= 0;
+  [linear] <c10>:  -<x_3>[C] +<x_7>[C] <= 0;
+  [linear] <c11>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c12>:  -<x_3>[C] -<x_7>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+abs((<Y_0>))+abs((<X_1>))+abs((<Y_1>))+<x5>*(-1) <= 0;
-Bounds
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+abs((<Y_0>))+abs((<X_1>))+abs((<Y_1>))+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_13.txt
+++ b/tests/snapshots/scip/genexpr_abs_13.txt
@@ -7,27 +7,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_2 <= +0
- c2: -1 x_3 <= +0
- c3: -1 x_0 +1 x_2 <= +0
- c4: -1 x_1 +1 x_3 <= +0
- c5: -1 x_0 -1 x_2 <= +0
- c6: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1)+3 <= 0;
-Bounds
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0>))+abs((<X_1>))+<x3>*(-1)+3 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_14.txt
+++ b/tests/snapshots/scip/genexpr_abs_14.txt
@@ -7,37 +7,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_4 <= +0
- c2: -1 x_5 <= +0
- c3: -1 x_6 <= +0
- c4: -1 x_7 <= +0
- c5: -1 x_0 +1 x_4 <= +0
- c6: -1 x_1 +1 x_5 <= +0
- c7: -1 x_2 +1 x_6 <= +0
- c8: -1 x_3 +1 x_7 <= +0
- c9: -1 x_0 -1 x_4 <= +0
- c10: -1 x_1 -1 x_5 <= +0
- c11: -1 x_2 -1 x_6 <= +0
- c12: -1 x_3 -1 x_7 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] +<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] +<x_6>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] +<x_7>[C] <= 0;
+  [linear] <c9>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c10>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c11>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c12>:  -<x_3>[C] -<x_7>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1) <= 0;
-Bounds
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_15.txt
+++ b/tests/snapshots/scip/genexpr_abs_15.txt
@@ -8,45 +8,53 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_4 <= +0
- c2: -1 x_5 <= +0
- c3: -1 x_6 <= +0
- c4: -1 x_7 <= +0
- c5: -1 x_8 <= +0
- c6: -1 x_9 <= +0
- c7: -1 x_10 <= +0
- c8: -1 x_11 <= +0
- c9: -1 x_0 +1 x_4 +1 x_8 <= +0
- c10: -1 x_1 +1 x_5 +1 x_9 <= +0
- c11: -1 x_2 +1 x_6 +1 x_10 <= +0
- c12: -1 x_3 +1 x_7 +1 x_11 <= +0
- c13: -1 x_0 -1 x_4 -1 x_8 <= +0
- c14: -1 x_1 -1 x_5 -1 x_9 <= +0
- c15: -1 x_2 -1 x_6 -1 x_10 <= +0
- c16: -1 x_3 -1 x_7 -1 x_11 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_8>[C] <= 0;
+  [linear] <c6>:  -<x_9>[C] <= 0;
+  [linear] <c7>:  -<x_10>[C] <= 0;
+  [linear] <c8>:  -<x_11>[C] <= 0;
+  [linear] <c9>:  -<x_0>[C] +<x_4>[C] +<x_8>[C] <= 0;
+  [linear] <c10>:  -<x_1>[C] +<x_5>[C] +<x_9>[C] <= 0;
+  [linear] <c11>:  -<x_2>[C] +<x_6>[C] +<x_10>[C] <= 0;
+  [linear] <c12>:  -<x_3>[C] +<x_7>[C] +<x_11>[C] <= 0;
+  [linear] <c13>:  -<x_0>[C] -<x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c14>:  -<x_1>[C] -<x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c15>:  -<x_2>[C] -<x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c16>:  -<x_3>[C] -<x_7>[C] -<x_11>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x9
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>+<Y_0_0>))+abs((<X_0_1>+<Y_0_1>))+abs((<X_1_0>+<Y_1_0>))+abs((<X_1_1>+<Y_1_1>))+<x9>*(-1) <= 0;
-Bounds
- x9 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x9>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>+<Y_0_0>))+abs((<X_0_1>+<Y_0_1>))+abs((<X_1_0>+<Y_1_0>))+abs((<X_1_1>+<Y_1_1>))+<x9>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_16.txt
+++ b/tests/snapshots/scip/genexpr_abs_16.txt
@@ -7,37 +7,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_4 <= +0
- c2: -1 x_5 <= +0
- c3: -1 x_6 <= +0
- c4: -1 x_7 <= +0
- c5: -1 x_0 +1 x_4 <= -1
- c6: -1 x_1 +1 x_5 <= -1
- c7: -1 x_2 +1 x_6 <= -1
- c8: -1 x_3 +1 x_7 <= -1
- c9: -1 x_0 -1 x_4 <= +1
- c10: -1 x_1 -1 x_5 <= +1
- c11: -1 x_2 -1 x_6 <= +1
- c12: -1 x_3 -1 x_7 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] +<x_4>[C] <= -1;
+  [linear] <c6>:  -<x_1>[C] +<x_5>[C] <= -1;
+  [linear] <c7>:  -<x_2>[C] +<x_6>[C] <= -1;
+  [linear] <c8>:  -<x_3>[C] +<x_7>[C] <= -1;
+  [linear] <c9>:  -<x_0>[C] -<x_4>[C] <= 1;
+  [linear] <c10>:  -<x_1>[C] -<x_5>[C] <= 1;
+  [linear] <c11>:  -<x_2>[C] -<x_6>[C] <= 1;
+  [linear] <c12>:  -<x_3>[C] -<x_7>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>+1))+abs((<X_0_1>+1))+abs((<X_1_0>+1))+abs((<X_1_1>+1))+<x5>*(-1) <= 0;
-Bounds
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>+1))+abs((<X_0_1>+1))+abs((<X_1_0>+1))+abs((<X_1_1>+1))+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_17.txt
+++ b/tests/snapshots/scip/genexpr_abs_17.txt
@@ -8,37 +8,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_4 <= +0
- c2: -1 x_5 <= +0
- c3: -1 x_6 <= +0
- c4: -1 x_7 <= +0
- c5: -1 x_0 +1 x_4 <= +0
- c6: -1 x_1 +1 x_5 <= +0
- c7: -1 x_2 +1 x_6 <= +0
- c8: -1 x_3 +1 x_7 <= +0
- c9: -1 x_0 -1 x_4 <= +0
- c10: -1 x_1 -1 x_5 <= +0
- c11: -1 x_2 -1 x_6 <= +0
- c12: -1 x_3 -1 x_7 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] +<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] +<x_6>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] +<x_7>[C] <= 0;
+  [linear] <c9>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c10>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c11>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c12>:  -<x_3>[C] -<x_7>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1)+6 <= 0;
-Bounds
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1)+6 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_18.txt
+++ b/tests/snapshots/scip/genexpr_abs_18.txt
@@ -8,57 +8,65 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5 +1 x_6 +1 x_7
-Subject to
- c1: -1 x_8 <= +0
- c2: -1 x_9 <= +0
- c3: -1 x_10 <= +0
- c4: -1 x_11 <= +0
- c5: -1 x_12 <= +0
- c6: -1 x_13 <= +0
- c7: -1 x_14 <= +0
- c8: -1 x_15 <= +0
- c9: -1 x_0 +1 x_8 <= +0
- c10: -1 x_1 +1 x_9 <= +0
- c11: -1 x_2 +1 x_10 <= +0
- c12: -1 x_3 +1 x_11 <= +0
- c13: -1 x_0 -1 x_8 <= +0
- c14: -1 x_1 -1 x_9 <= +0
- c15: -1 x_2 -1 x_10 <= +0
- c16: -1 x_3 -1 x_11 <= +0
- c17: -1 x_4 +1 x_12 <= +0
- c18: -1 x_5 +1 x_13 <= +0
- c19: -1 x_6 +1 x_14 <= +0
- c20: -1 x_7 +1 x_15 <= +0
- c21: -1 x_4 -1 x_12 <= +0
- c22: -1 x_5 -1 x_13 <= +0
- c23: -1 x_6 -1 x_14 <= +0
- c24: -1 x_7 -1 x_15 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
- x_12 free
- x_13 free
- x_14 free
- x_15 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_12>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_13>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_14>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_15>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_8>[C] <= 0;
+  [linear] <c2>:  -<x_9>[C] <= 0;
+  [linear] <c3>:  -<x_10>[C] <= 0;
+  [linear] <c4>:  -<x_11>[C] <= 0;
+  [linear] <c5>:  -<x_12>[C] <= 0;
+  [linear] <c6>:  -<x_13>[C] <= 0;
+  [linear] <c7>:  -<x_14>[C] <= 0;
+  [linear] <c8>:  -<x_15>[C] <= 0;
+  [linear] <c9>:  -<x_0>[C] +<x_8>[C] <= 0;
+  [linear] <c10>:  -<x_1>[C] +<x_9>[C] <= 0;
+  [linear] <c11>:  -<x_2>[C] +<x_10>[C] <= 0;
+  [linear] <c12>:  -<x_3>[C] +<x_11>[C] <= 0;
+  [linear] <c13>:  -<x_0>[C] -<x_8>[C] <= 0;
+  [linear] <c14>:  -<x_1>[C] -<x_9>[C] <= 0;
+  [linear] <c15>:  -<x_2>[C] -<x_10>[C] <= 0;
+  [linear] <c16>:  -<x_3>[C] -<x_11>[C] <= 0;
+  [linear] <c17>:  -<x_4>[C] +<x_12>[C] <= 0;
+  [linear] <c18>:  -<x_5>[C] +<x_13>[C] <= 0;
+  [linear] <c19>:  -<x_6>[C] +<x_14>[C] <= 0;
+  [linear] <c20>:  -<x_7>[C] +<x_15>[C] <= 0;
+  [linear] <c21>:  -<x_4>[C] -<x_12>[C] <= 0;
+  [linear] <c22>:  -<x_5>[C] -<x_13>[C] <= 0;
+  [linear] <c23>:  -<x_6>[C] -<x_14>[C] <= 0;
+  [linear] <c24>:  -<x_7>[C] -<x_15>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x9
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>))+abs((<Y_0_0>))+abs((<X_0_1>))+abs((<Y_0_1>))+abs((<X_1_0>))+abs((<Y_1_0>))+abs((<X_1_1>))+abs((<Y_1_1>))+<x9>*(-1) <= 0;
-Bounds
- x9 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x9>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>))+abs((<Y_0_0>))+abs((<X_0_1>))+abs((<Y_0_1>))+abs((<X_1_0>))+abs((<Y_1_0>))+abs((<X_1_1>))+abs((<Y_1_1>))+<x9>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_abs_19.txt
+++ b/tests/snapshots/scip/genexpr_abs_19.txt
@@ -8,37 +8,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_4 <= +0
- c2: -1 x_5 <= +0
- c3: -1 x_6 <= +0
- c4: -1 x_7 <= +0
- c5: -1 x_0 +1 x_4 <= +0
- c6: -1 x_1 +1 x_5 <= +0
- c7: -1 x_2 +1 x_6 <= +0
- c8: -1 x_3 +1 x_7 <= +0
- c9: -1 x_0 -1 x_4 <= +0
- c10: -1 x_1 -1 x_5 <= +0
- c11: -1 x_2 -1 x_6 <= +0
- c12: -1 x_3 -1 x_7 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] +<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] +<x_6>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] +<x_7>[C] <= 0;
+  [linear] <c9>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c10>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c11>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c12>:  -<x_3>[C] -<x_7>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1)+10 <= 0;
-Bounds
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1)+10 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_min_max_00.txt
+++ b/tests/snapshots/scip/genexpr_min_max_00.txt
@@ -8,21 +8,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 6: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <6>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_01.txt
+++ b/tests/snapshots/scip/genexpr_min_max_01.txt
@@ -8,21 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x +1
-Subject to
- 12: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <12>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_02.txt
+++ b/tests/snapshots/scip/genexpr_min_max_02.txt
@@ -10,27 +10,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_3 <= +0
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x +1 y
-Subject to
- 19: +1 x <= +1
- 23: +1 y <= +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <19>: <x>[C] <= 1;
+  [linear] <23>: <y>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_03.txt
+++ b/tests/snapshots/scip/genexpr_min_max_03.txt
@@ -10,25 +10,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 -1 x_2 <= +0
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x +1 y
-Subject to
- 29: +1 x <= +1
- 33: +1 y <= +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <29>: <x>[C] <= 1;
+  [linear] <33>: <y>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_04.txt
+++ b/tests/snapshots/scip/genexpr_min_max_04.txt
@@ -8,21 +8,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 4: +1 x >= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <4>: <x>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_05.txt
+++ b/tests/snapshots/scip/genexpr_min_max_05.txt
@@ -8,21 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1
-Subject to
- 10: +1 x >= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <10>: <x>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_06.txt
+++ b/tests/snapshots/scip/genexpr_min_max_06.txt
@@ -10,27 +10,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 +1 x_2 <= +0
- c2: -1 x_1 +1 x_3 <= +0
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1 y
-Subject to
- 17: +1 x >= +1
- 21: +1 y >= +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <17>: <x>[C] >= 1;
+  [linear] <21>: <y>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_07.txt
+++ b/tests/snapshots/scip/genexpr_min_max_07.txt
@@ -10,25 +10,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 +1 x_2 <= +0
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1 y
-Subject to
- 27: +1 x >= +1
- 31: +1 y >= +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <27>: <x>[C] >= 1;
+  [linear] <31>: <y>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_08.txt
+++ b/tests/snapshots/scip/genexpr_min_max_08.txt
@@ -8,21 +8,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
- 6_0: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <6_0>: <x_0>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_09.txt
+++ b/tests/snapshots/scip/genexpr_min_max_09.txt
@@ -8,21 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1
-Subject to
- 12_0: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <12_0>: <x_0>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_10.txt
+++ b/tests/snapshots/scip/genexpr_min_max_10.txt
@@ -10,27 +10,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_3 <= +0
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 y
-Subject to
- 19_0: +1 x_0 <= +1
- 23: +1 y <= +1
-Bounds
- x_0 free
- y free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <19_0>: <x_0>[C] <= 1;
+  [linear] <23>: <y>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_11.txt
+++ b/tests/snapshots/scip/genexpr_min_max_11.txt
@@ -10,25 +10,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 -1 x_2 <= +0
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 y
-Subject to
- 29_0: +1 x_0 <= +1
- 33: +1 y <= +1
-Bounds
- x_0 free
- y free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <29_0>: <x_0>[C] <= 1;
+  [linear] <33>: <y>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_12.txt
+++ b/tests/snapshots/scip/genexpr_min_max_12.txt
@@ -8,21 +8,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
- 4_0: +1 x_0 >= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <4_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_13.txt
+++ b/tests/snapshots/scip/genexpr_min_max_13.txt
@@ -8,21 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1
-Subject to
- 10_0: +1 x_0 >= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <10_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_14.txt
+++ b/tests/snapshots/scip/genexpr_min_max_14.txt
@@ -10,27 +10,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 +1 x_2 <= +0
- c2: -1 x_1 +1 x_3 <= +0
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 y
-Subject to
- 17_0: +1 x_0 >= +1
- 21: +1 y >= +1
-Bounds
- x_0 free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <17_0>: <x_0>[C] >= 1;
+  [linear] <21>: <y>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_15.txt
+++ b/tests/snapshots/scip/genexpr_min_max_15.txt
@@ -10,25 +10,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 +1 x_2 <= +0
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 y
-Subject to
- 27_0: +1 x_0 >= +1
- 31: +1 y >= +1
-Bounds
- x_0 free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <27_0>: <x_0>[C] >= 1;
+  [linear] <31>: <y>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_16.txt
+++ b/tests/snapshots/scip/genexpr_min_max_16.txt
@@ -8,29 +8,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: -1 x_0 -1 x_2 <= +0
- c3: +1 x_1 <= +1
- c4: +1 x_2 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_1>[C] <= 1;
+  [linear] <c4>: <x_2>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 min_1
-Subject to
- min_1_0: +1 X_0 -1 min_1 >= +0
- min_1_1: +1 X_1 -1 min_1 >= +0
- 7_0: +1 X_0 <= +1
- 7_1: +1 X_1 <= +1
-Bounds
- X_0 free
- X_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0>: <X_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1>: <X_1>[C] -<min_1>[C] >= 0;
+  [linear] <7_0>: <X_0>[C] <= 1;
+  [linear] <7_1>: <X_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_17.txt
+++ b/tests/snapshots/scip/genexpr_min_max_17.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- min_1_0: +1 X_0 -1 min_1 >= +0
- min_1_1: +1 X_1 -1 min_1 >= +0
- 13: +1 min_1 >= +1
-Bounds
- X_0 free
- X_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0>: <X_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1>: <X_1>[C] -<min_1>[C] >= 0;
+  [linear] <13>: <min_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_18.txt
+++ b/tests/snapshots/scip/genexpr_min_max_18.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- min_1_0: +1 X_0 -1 min_1 >= +0
- min_1_1: +1 X_1 -1 min_1 >= +0
- 20: +1 min_1 >= +0
-Bounds
- X_0 free
- X_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0>: <X_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1>: <X_1>[C] -<min_1>[C] >= 0;
+  [linear] <20>: <min_1>[C] >= 0;
+END

--- a/tests/snapshots/scip/genexpr_min_max_19.txt
+++ b/tests/snapshots/scip/genexpr_min_max_19.txt
@@ -10,41 +10,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_3 = +1
- c2: +1 x_4 = +1
- c3: -1 x_0 -1 x_2 <= +0
- c4: -1 x_1 -1 x_2 <= +0
- c5: -1 x_3 -1 x_5 <= +0
- c6: -1 x_4 -1 x_5 <= +0
- c7: +1 x_2 +1 x_5 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_3>[C] == 1;
+  [linear] <c2>: <x_4>[C] == 1;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c5>:  -<x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c6>:  -<x_4>[C] -<x_5>[C] <= 0;
+  [linear] <c7>: <x_2>[C] +<x_5>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- min_1_0: +1 X_0 -1 min_1 >= +0
- min_1_1: +1 X_1 -1 min_1 >= +0
- min_2_0: +1 Y_0 -1 min_2 >= +0
- min_2_1: +1 Y_1 -1 min_2 >= +0
- 28: +1 min_1 +1 min_2 >= +1
- 33_0: +1 Y_0 = +1
- 33_1: +1 Y_1 = +1
-Bounds
- X_0 free
- X_1 free
- min_1 free
- Y_0 free
- Y_1 free
- min_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <min_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0>: <X_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1>: <X_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_2_0>: <Y_0>[C] -<min_2>[C] >= 0;
+  [linear] <min_2_1>: <Y_1>[C] -<min_2>[C] >= 0;
+  [linear] <28>: <min_1>[C] +<min_2>[C] >= 1;
+  [linear] <33_0>: <Y_0>[C] == 1;
+  [linear] <33_1>: <Y_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_20.txt
+++ b/tests/snapshots/scip/genexpr_min_max_20.txt
@@ -10,35 +10,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_2 = +1
- c2: +1 x_3 = +1
- c3: -1 x_0 -1 x_2 -1 x_4 <= +0
- c4: -1 x_1 -1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_2>[C] == 1;
+  [linear] <c2>: <x_3>[C] == 1;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- min_1_0: +1 X_0 +1 Y_0 -1 min_1 >= +0
- min_1_1: +1 X_1 +1 Y_1 -1 min_1 >= +0
- 40: +1 min_1 >= +1
- 45_0: +1 Y_0 = +1
- 45_1: +1 Y_1 = +1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0>: <X_0>[C] +<Y_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1>: <X_1>[C] +<Y_1>[C] -<min_1>[C] >= 0;
+  [linear] <40>: <min_1>[C] >= 1;
+  [linear] <45_0>: <Y_0>[C] == 1;
+  [linear] <45_1>: <Y_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_21.txt
+++ b/tests/snapshots/scip/genexpr_min_max_21.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +1
- c2: -1 x_1 -1 x_2 <= -2
- c3: +1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 1;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= -2;
+  [linear] <c3>: <x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- min_1_0: +1 X_0 -1 min_1 >= -1
- min_1_1: +1 X_1 -1 min_1 >= +2
- 52: +1 min_1 >= +1
-Bounds
- X_0 free
- X_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0>: <X_0>[C] -<min_1>[C] >= -1;
+  [linear] <min_1_1>: <X_1>[C] -<min_1>[C] >= 2;
+  [linear] <52>: <min_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_22.txt
+++ b/tests/snapshots/scip/genexpr_min_max_22.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= -3
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= -3;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- min_1_0: +1 X_0 -1 min_1 >= +0
- min_1_1: +1 X_1 -1 min_1 >= +0
- 60: +1 min_1 >= +3
-Bounds
- X_0 free
- X_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0>: <X_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1>: <X_1>[C] -<min_1>[C] >= 0;
+  [linear] <60>: <min_1>[C] >= 3;
+END

--- a/tests/snapshots/scip/genexpr_min_max_23.txt
+++ b/tests/snapshots/scip/genexpr_min_max_23.txt
@@ -8,29 +8,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 +1 x_2 <= +0
- c3: -1 x_1 <= -1
- c4: -1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_1>[C] <= -1;
+  [linear] <c4>:  -<x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 max_1
-Subject to
- max_1_0: +1 X_0 -1 max_1 <= +0
- max_1_1: +1 X_1 -1 max_1 <= +0
- 5_0: +1 X_0 >= +1
- 5_1: +1 X_1 >= +1
-Bounds
- X_0 free
- X_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0>: <X_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1>: <X_1>[C] -<max_1>[C] <= 0;
+  [linear] <5_0>: <X_0>[C] >= 1;
+  [linear] <5_1>: <X_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_24.txt
+++ b/tests/snapshots/scip/genexpr_min_max_24.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- max_1_0: +1 X_0 -1 max_1 <= +0
- max_1_1: +1 X_1 -1 max_1 <= +0
- 11: +1 max_1 <= +1
-Bounds
- X_0 free
- X_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0>: <X_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1>: <X_1>[C] -<max_1>[C] <= 0;
+  [linear] <11>: <max_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_25.txt
+++ b/tests/snapshots/scip/genexpr_min_max_25.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- max_1_0: +1 X_0 -1 max_1 <= +0
- max_1_1: +1 X_1 -1 max_1 <= +0
- 18: +1 max_1 <= +0
-Bounds
- X_0 free
- X_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0>: <X_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1>: <X_1>[C] -<max_1>[C] <= 0;
+  [linear] <18>: <max_1>[C] <= 0;
+END

--- a/tests/snapshots/scip/genexpr_min_max_26.txt
+++ b/tests/snapshots/scip/genexpr_min_max_26.txt
@@ -10,41 +10,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_3 = +1
- c2: +1 x_4 = +1
- c3: +1 x_0 -1 x_2 <= +0
- c4: +1 x_1 -1 x_2 <= +0
- c5: +1 x_3 -1 x_5 <= +0
- c6: +1 x_4 -1 x_5 <= +0
- c7: +1 x_2 +1 x_5 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_3>[C] == 1;
+  [linear] <c2>: <x_4>[C] == 1;
+  [linear] <c3>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c5>: <x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c6>: <x_4>[C] -<x_5>[C] <= 0;
+  [linear] <c7>: <x_2>[C] +<x_5>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- max_1_0: +1 X_0 -1 max_1 <= +0
- max_1_1: +1 X_1 -1 max_1 <= +0
- max_2_0: +1 Y_0 -1 max_2 <= +0
- max_2_1: +1 Y_1 -1 max_2 <= +0
- 26: +1 max_1 +1 max_2 <= +1
- 31_0: +1 Y_0 = +1
- 31_1: +1 Y_1 = +1
-Bounds
- X_0 free
- X_1 free
- max_1 free
- Y_0 free
- Y_1 free
- max_2 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <max_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0>: <X_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1>: <X_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_2_0>: <Y_0>[C] -<max_2>[C] <= 0;
+  [linear] <max_2_1>: <Y_1>[C] -<max_2>[C] <= 0;
+  [linear] <26>: <max_1>[C] +<max_2>[C] <= 1;
+  [linear] <31_0>: <Y_0>[C] == 1;
+  [linear] <31_1>: <Y_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_27.txt
+++ b/tests/snapshots/scip/genexpr_min_max_27.txt
@@ -10,35 +10,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_2 = +1
- c2: +1 x_3 = +1
- c3: +1 x_0 +1 x_2 -1 x_4 <= +0
- c4: +1 x_1 +1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_2>[C] == 1;
+  [linear] <c2>: <x_3>[C] == 1;
+  [linear] <c3>: <x_0>[C] +<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_1>[C] +<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- max_1_0: +1 X_0 +1 Y_0 -1 max_1 <= +0
- max_1_1: +1 X_1 +1 Y_1 -1 max_1 <= +0
- 38: +1 max_1 <= +1
- 43_0: +1 Y_0 = +1
- 43_1: +1 Y_1 = +1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0>: <X_0>[C] +<Y_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1>: <X_1>[C] +<Y_1>[C] -<max_1>[C] <= 0;
+  [linear] <38>: <max_1>[C] <= 1;
+  [linear] <43_0>: <Y_0>[C] == 1;
+  [linear] <43_1>: <Y_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_28.txt
+++ b/tests/snapshots/scip/genexpr_min_max_28.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= -1
- c2: +1 x_1 -1 x_2 <= +2
- c3: +1 x_2 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= -1;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 2;
+  [linear] <c3>: <x_2>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- max_1_0: +1 X_0 -1 max_1 <= -1
- max_1_1: +1 X_1 -1 max_1 <= +2
- 50: +1 max_1 <= +1
-Bounds
- X_0 free
- X_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0>: <X_0>[C] -<max_1>[C] <= -1;
+  [linear] <max_1_1>: <X_1>[C] -<max_1>[C] <= 2;
+  [linear] <50>: <max_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_29.txt
+++ b/tests/snapshots/scip/genexpr_min_max_29.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- max_1_0: +1 X_0 -1 max_1 <= +0
- max_1_1: +1 X_1 -1 max_1 <= +0
- 58: +1 max_1 <= +0
-Bounds
- X_0 free
- X_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0>: <X_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1>: <X_1>[C] -<max_1>[C] <= 0;
+  [linear] <58>: <max_1>[C] <= 0;
+END

--- a/tests/snapshots/scip/genexpr_min_max_30.txt
+++ b/tests/snapshots/scip/genexpr_min_max_30.txt
@@ -8,41 +8,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: -1 x_0 -1 x_2 <= +0
- c3: -1 x_0 -1 x_3 <= +0
- c4: -1 x_0 -1 x_4 <= +0
- c5: +1 x_1 <= +1
- c6: +1 x_2 <= +1
- c7: +1 x_3 <= +1
- c8: +1 x_4 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] -<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_1>[C] <= 1;
+  [linear] <c6>: <x_2>[C] <= 1;
+  [linear] <c7>: <x_3>[C] <= 1;
+  [linear] <c8>: <x_4>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 min_1
-Subject to
- min_1_0_0: +1 X_0_0 -1 min_1 >= +0
- min_1_0_1: +1 X_0_1 -1 min_1 >= +0
- min_1_1_0: +1 X_1_0 -1 min_1 >= +0
- min_1_1_1: +1 X_1_1 -1 min_1 >= +0
- 7_0_0: +1 X_0_0 <= +1
- 7_0_1: +1 X_0_1 <= +1
- 7_1_0: +1 X_1_0 <= +1
- 7_1_1: +1 X_1_1 <= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0_0>: <X_0_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_0_1>: <X_0_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_0>: <X_1_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_1>: <X_1_1>[C] -<min_1>[C] >= 0;
+  [linear] <7_0_0>: <X_0_0>[C] <= 1;
+  [linear] <7_0_1>: <X_0_1>[C] <= 1;
+  [linear] <7_1_0>: <X_1_0>[C] <= 1;
+  [linear] <7_1_1>: <X_1_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_31.txt
+++ b/tests/snapshots/scip/genexpr_min_max_31.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +0
- c2: -1 x_1 -1 x_4 <= +0
- c3: -1 x_2 -1 x_4 <= +0
- c4: -1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- min_1_0_0: +1 X_0_0 -1 min_1 >= +0
- min_1_0_1: +1 X_0_1 -1 min_1 >= +0
- min_1_1_0: +1 X_1_0 -1 min_1 >= +0
- min_1_1_1: +1 X_1_1 -1 min_1 >= +0
- 13: +1 min_1 >= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0_0>: <X_0_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_0_1>: <X_0_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_0>: <X_1_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_1>: <X_1_1>[C] -<min_1>[C] >= 0;
+  [linear] <13>: <min_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_32.txt
+++ b/tests/snapshots/scip/genexpr_min_max_32.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +0
- c2: -1 x_1 -1 x_4 <= +0
- c3: -1 x_2 -1 x_4 <= +0
- c4: -1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- min_1_0_0: +1 X_0_0 -1 min_1 >= +0
- min_1_0_1: +1 X_0_1 -1 min_1 >= +0
- min_1_1_0: +1 X_1_0 -1 min_1 >= +0
- min_1_1_1: +1 X_1_1 -1 min_1 >= +0
- 20: +1 min_1 >= +0
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0_0>: <X_0_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_0_1>: <X_0_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_0>: <X_1_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_1>: <X_1_1>[C] -<min_1>[C] >= 0;
+  [linear] <20>: <min_1>[C] >= 0;
+END

--- a/tests/snapshots/scip/genexpr_min_max_33.txt
+++ b/tests/snapshots/scip/genexpr_min_max_33.txt
@@ -10,61 +10,61 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: +1 x_5 = +1
- c2: +1 x_6 = +1
- c3: +1 x_7 = +1
- c4: +1 x_8 = +1
- c5: -1 x_0 -1 x_4 <= +0
- c6: -1 x_1 -1 x_4 <= +0
- c7: -1 x_2 -1 x_4 <= +0
- c8: -1 x_3 -1 x_4 <= +0
- c9: -1 x_5 -1 x_9 <= +0
- c10: -1 x_6 -1 x_9 <= +0
- c11: -1 x_7 -1 x_9 <= +0
- c12: -1 x_8 -1 x_9 <= +0
- c13: +1 x_4 +1 x_9 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_5>[C] == 1;
+  [linear] <c2>: <x_6>[C] == 1;
+  [linear] <c3>: <x_7>[C] == 1;
+  [linear] <c4>: <x_8>[C] == 1;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c9>:  -<x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c10>:  -<x_6>[C] -<x_9>[C] <= 0;
+  [linear] <c11>:  -<x_7>[C] -<x_9>[C] <= 0;
+  [linear] <c12>:  -<x_8>[C] -<x_9>[C] <= 0;
+  [linear] <c13>: <x_4>[C] +<x_9>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- min_1_0_0: +1 X_0_0 -1 min_1 >= +0
- min_1_0_1: +1 X_0_1 -1 min_1 >= +0
- min_1_1_0: +1 X_1_0 -1 min_1 >= +0
- min_1_1_1: +1 X_1_1 -1 min_1 >= +0
- min_2_0_0: +1 Y_0_0 -1 min_2 >= +0
- min_2_0_1: +1 Y_0_1 -1 min_2 >= +0
- min_2_1_0: +1 Y_1_0 -1 min_2 >= +0
- min_2_1_1: +1 Y_1_1 -1 min_2 >= +0
- 28: +1 min_1 +1 min_2 >= +1
- 33_0_0: +1 Y_0_0 = +1
- 33_0_1: +1 Y_0_1 = +1
- 33_1_0: +1 Y_1_0 = +1
- 33_1_1: +1 Y_1_1 = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- min_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- min_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <min_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0_0>: <X_0_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_0_1>: <X_0_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_0>: <X_1_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_1>: <X_1_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_2_0_0>: <Y_0_0>[C] -<min_2>[C] >= 0;
+  [linear] <min_2_0_1>: <Y_0_1>[C] -<min_2>[C] >= 0;
+  [linear] <min_2_1_0>: <Y_1_0>[C] -<min_2>[C] >= 0;
+  [linear] <min_2_1_1>: <Y_1_1>[C] -<min_2>[C] >= 0;
+  [linear] <28>: <min_1>[C] +<min_2>[C] >= 1;
+  [linear] <33_0_0>: <Y_0_0>[C] == 1;
+  [linear] <33_0_1>: <Y_0_1>[C] == 1;
+  [linear] <33_1_0>: <Y_1_0>[C] == 1;
+  [linear] <33_1_1>: <Y_1_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_34.txt
+++ b/tests/snapshots/scip/genexpr_min_max_34.txt
@@ -10,51 +10,51 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: +1 x_4 = +1
- c2: +1 x_5 = +1
- c3: +1 x_6 = +1
- c4: +1 x_7 = +1
- c5: -1 x_0 -1 x_4 -1 x_8 <= +0
- c6: -1 x_1 -1 x_5 -1 x_8 <= +0
- c7: -1 x_2 -1 x_6 -1 x_8 <= +0
- c8: -1 x_3 -1 x_7 -1 x_8 <= +0
- c9: +1 x_8 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_4>[C] == 1;
+  [linear] <c2>: <x_5>[C] == 1;
+  [linear] <c3>: <x_6>[C] == 1;
+  [linear] <c4>: <x_7>[C] == 1;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_5>[C] -<x_8>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] -<x_6>[C] -<x_8>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] -<x_7>[C] -<x_8>[C] <= 0;
+  [linear] <c9>: <x_8>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- min_1_0_0: +1 X_0_0 +1 Y_0_0 -1 min_1 >= +0
- min_1_0_1: +1 X_0_1 +1 Y_0_1 -1 min_1 >= +0
- min_1_1_0: +1 X_1_0 +1 Y_1_0 -1 min_1 >= +0
- min_1_1_1: +1 X_1_1 +1 Y_1_1 -1 min_1 >= +0
- 40: +1 min_1 >= +1
- 45_0_0: +1 Y_0_0 = +1
- 45_0_1: +1 Y_0_1 = +1
- 45_1_0: +1 Y_1_0 = +1
- 45_1_1: +1 Y_1_1 = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0_0>: <X_0_0>[C] +<Y_0_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_0_1>: <X_0_1>[C] +<Y_0_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_0>: <X_1_0>[C] +<Y_1_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_1>: <X_1_1>[C] +<Y_1_1>[C] -<min_1>[C] >= 0;
+  [linear] <40>: <min_1>[C] >= 1;
+  [linear] <45_0_0>: <Y_0_0>[C] == 1;
+  [linear] <45_0_1>: <Y_0_1>[C] == 1;
+  [linear] <45_1_0>: <Y_1_0>[C] == 1;
+  [linear] <45_1_1>: <Y_1_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_35.txt
+++ b/tests/snapshots/scip/genexpr_min_max_35.txt
@@ -9,35 +9,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +1
- c2: -1 x_1 -1 x_4 <= +3
- c3: -1 x_2 -1 x_4 <= -2
- c4: -1 x_3 -1 x_4 <= +4
- c5: +1 x_4 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 1;
+  [linear] <c2>:  -<x_1>[C] -<x_4>[C] <= 3;
+  [linear] <c3>:  -<x_2>[C] -<x_4>[C] <= -2;
+  [linear] <c4>:  -<x_3>[C] -<x_4>[C] <= 4;
+  [linear] <c5>: <x_4>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- min_1_0_0: +1 X_0_0 -1 min_1 >= -1
- min_1_0_1: +1 X_0_1 -1 min_1 >= +2
- min_1_1_0: +1 X_1_0 -1 min_1 >= -3
- min_1_1_1: +1 X_1_1 -1 min_1 >= -4
- 52: +1 min_1 >= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0_0>: <X_0_0>[C] -<min_1>[C] >= -1;
+  [linear] <min_1_0_1>: <X_0_1>[C] -<min_1>[C] >= 2;
+  [linear] <min_1_1_0>: <X_1_0>[C] -<min_1>[C] >= -3;
+  [linear] <min_1_1_1>: <X_1_1>[C] -<min_1>[C] >= -4;
+  [linear] <52>: <min_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_36.txt
+++ b/tests/snapshots/scip/genexpr_min_max_36.txt
@@ -9,35 +9,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +0
- c2: -1 x_1 -1 x_4 <= +0
- c3: -1 x_2 -1 x_4 <= +0
- c4: -1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= -3
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= -3;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- min_1_0_0: +1 X_0_0 -1 min_1 >= +0
- min_1_0_1: +1 X_0_1 -1 min_1 >= +0
- min_1_1_0: +1 X_1_0 -1 min_1 >= +0
- min_1_1_1: +1 X_1_1 -1 min_1 >= +0
- 60: +1 min_1 >= +3
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- min_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <min_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <min_1_0_0>: <X_0_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_0_1>: <X_0_1>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_0>: <X_1_0>[C] -<min_1>[C] >= 0;
+  [linear] <min_1_1_1>: <X_1_1>[C] -<min_1>[C] >= 0;
+  [linear] <60>: <min_1>[C] >= 3;
+END

--- a/tests/snapshots/scip/genexpr_min_max_37.txt
+++ b/tests/snapshots/scip/genexpr_min_max_37.txt
@@ -8,41 +8,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 +1 x_2 <= +0
- c3: -1 x_0 +1 x_3 <= +0
- c4: -1 x_0 +1 x_4 <= +0
- c5: -1 x_1 <= -1
- c6: -1 x_2 <= -1
- c7: -1 x_3 <= -1
- c8: -1 x_4 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] +<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c5>:  -<x_1>[C] <= -1;
+  [linear] <c6>:  -<x_2>[C] <= -1;
+  [linear] <c7>:  -<x_3>[C] <= -1;
+  [linear] <c8>:  -<x_4>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 max_1
-Subject to
- max_1_0_0: +1 X_0_0 -1 max_1 <= +0
- max_1_0_1: +1 X_0_1 -1 max_1 <= +0
- max_1_1_0: +1 X_1_0 -1 max_1 <= +0
- max_1_1_1: +1 X_1_1 -1 max_1 <= +0
- 5_0_0: +1 X_0_0 >= +1
- 5_0_1: +1 X_0_1 >= +1
- 5_1_0: +1 X_1_0 >= +1
- 5_1_1: +1 X_1_1 >= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0_0>: <X_0_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_0_1>: <X_0_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_0>: <X_1_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_1>: <X_1_1>[C] -<max_1>[C] <= 0;
+  [linear] <5_0_0>: <X_0_0>[C] >= 1;
+  [linear] <5_0_1>: <X_0_1>[C] >= 1;
+  [linear] <5_1_0>: <X_1_0>[C] >= 1;
+  [linear] <5_1_1>: <X_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_38.txt
+++ b/tests/snapshots/scip/genexpr_min_max_38.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_4 <= +0
- c3: +1 x_2 -1 x_4 <= +0
- c4: +1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- max_1_0_0: +1 X_0_0 -1 max_1 <= +0
- max_1_0_1: +1 X_0_1 -1 max_1 <= +0
- max_1_1_0: +1 X_1_0 -1 max_1 <= +0
- max_1_1_1: +1 X_1_1 -1 max_1 <= +0
- 11: +1 max_1 <= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0_0>: <X_0_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_0_1>: <X_0_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_0>: <X_1_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_1>: <X_1_1>[C] -<max_1>[C] <= 0;
+  [linear] <11>: <max_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_39.txt
+++ b/tests/snapshots/scip/genexpr_min_max_39.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_4 <= +0
- c3: +1 x_2 -1 x_4 <= +0
- c4: +1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- max_1_0_0: +1 X_0_0 -1 max_1 <= +0
- max_1_0_1: +1 X_0_1 -1 max_1 <= +0
- max_1_1_0: +1 X_1_0 -1 max_1 <= +0
- max_1_1_1: +1 X_1_1 -1 max_1 <= +0
- 18: +1 max_1 <= +0
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0_0>: <X_0_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_0_1>: <X_0_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_0>: <X_1_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_1>: <X_1_1>[C] -<max_1>[C] <= 0;
+  [linear] <18>: <max_1>[C] <= 0;
+END

--- a/tests/snapshots/scip/genexpr_min_max_40.txt
+++ b/tests/snapshots/scip/genexpr_min_max_40.txt
@@ -10,61 +10,61 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_5 = +1
- c2: +1 x_6 = +1
- c3: +1 x_7 = +1
- c4: +1 x_8 = +1
- c5: +1 x_0 -1 x_4 <= +0
- c6: +1 x_1 -1 x_4 <= +0
- c7: +1 x_2 -1 x_4 <= +0
- c8: +1 x_3 -1 x_4 <= +0
- c9: +1 x_5 -1 x_9 <= +0
- c10: +1 x_6 -1 x_9 <= +0
- c11: +1 x_7 -1 x_9 <= +0
- c12: +1 x_8 -1 x_9 <= +0
- c13: +1 x_4 +1 x_9 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_5>[C] == 1;
+  [linear] <c2>: <x_6>[C] == 1;
+  [linear] <c3>: <x_7>[C] == 1;
+  [linear] <c4>: <x_8>[C] == 1;
+  [linear] <c5>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>: <x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c7>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c8>: <x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c9>: <x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c10>: <x_6>[C] -<x_9>[C] <= 0;
+  [linear] <c11>: <x_7>[C] -<x_9>[C] <= 0;
+  [linear] <c12>: <x_8>[C] -<x_9>[C] <= 0;
+  [linear] <c13>: <x_4>[C] +<x_9>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- max_1_0_0: +1 X_0_0 -1 max_1 <= +0
- max_1_0_1: +1 X_0_1 -1 max_1 <= +0
- max_1_1_0: +1 X_1_0 -1 max_1 <= +0
- max_1_1_1: +1 X_1_1 -1 max_1 <= +0
- max_2_0_0: +1 Y_0_0 -1 max_2 <= +0
- max_2_0_1: +1 Y_0_1 -1 max_2 <= +0
- max_2_1_0: +1 Y_1_0 -1 max_2 <= +0
- max_2_1_1: +1 Y_1_1 -1 max_2 <= +0
- 26: +1 max_1 +1 max_2 <= +1
- 31_0_0: +1 Y_0_0 = +1
- 31_0_1: +1 Y_0_1 = +1
- 31_1_0: +1 Y_1_0 = +1
- 31_1_1: +1 Y_1_1 = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- max_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- max_2 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <max_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0_0>: <X_0_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_0_1>: <X_0_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_0>: <X_1_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_1>: <X_1_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_2_0_0>: <Y_0_0>[C] -<max_2>[C] <= 0;
+  [linear] <max_2_0_1>: <Y_0_1>[C] -<max_2>[C] <= 0;
+  [linear] <max_2_1_0>: <Y_1_0>[C] -<max_2>[C] <= 0;
+  [linear] <max_2_1_1>: <Y_1_1>[C] -<max_2>[C] <= 0;
+  [linear] <26>: <max_1>[C] +<max_2>[C] <= 1;
+  [linear] <31_0_0>: <Y_0_0>[C] == 1;
+  [linear] <31_0_1>: <Y_0_1>[C] == 1;
+  [linear] <31_1_0>: <Y_1_0>[C] == 1;
+  [linear] <31_1_1>: <Y_1_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_41.txt
+++ b/tests/snapshots/scip/genexpr_min_max_41.txt
@@ -10,51 +10,51 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_4 = +1
- c2: +1 x_5 = +1
- c3: +1 x_6 = +1
- c4: +1 x_7 = +1
- c5: +1 x_0 +1 x_4 -1 x_8 <= +0
- c6: +1 x_1 +1 x_5 -1 x_8 <= +0
- c7: +1 x_2 +1 x_6 -1 x_8 <= +0
- c8: +1 x_3 +1 x_7 -1 x_8 <= +0
- c9: +1 x_8 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_4>[C] == 1;
+  [linear] <c2>: <x_5>[C] == 1;
+  [linear] <c3>: <x_6>[C] == 1;
+  [linear] <c4>: <x_7>[C] == 1;
+  [linear] <c5>: <x_0>[C] +<x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>: <x_1>[C] +<x_5>[C] -<x_8>[C] <= 0;
+  [linear] <c7>: <x_2>[C] +<x_6>[C] -<x_8>[C] <= 0;
+  [linear] <c8>: <x_3>[C] +<x_7>[C] -<x_8>[C] <= 0;
+  [linear] <c9>: <x_8>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- max_1_0_0: +1 X_0_0 +1 Y_0_0 -1 max_1 <= +0
- max_1_0_1: +1 X_0_1 +1 Y_0_1 -1 max_1 <= +0
- max_1_1_0: +1 X_1_0 +1 Y_1_0 -1 max_1 <= +0
- max_1_1_1: +1 X_1_1 +1 Y_1_1 -1 max_1 <= +0
- 38: +1 max_1 <= +1
- 43_0_0: +1 Y_0_0 = +1
- 43_0_1: +1 Y_0_1 = +1
- 43_1_0: +1 Y_1_0 = +1
- 43_1_1: +1 Y_1_1 = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0_0>: <X_0_0>[C] +<Y_0_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_0_1>: <X_0_1>[C] +<Y_0_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_0>: <X_1_0>[C] +<Y_1_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_1>: <X_1_1>[C] +<Y_1_1>[C] -<max_1>[C] <= 0;
+  [linear] <38>: <max_1>[C] <= 1;
+  [linear] <43_0_0>: <Y_0_0>[C] == 1;
+  [linear] <43_0_1>: <Y_0_1>[C] == 1;
+  [linear] <43_1_0>: <Y_1_0>[C] == 1;
+  [linear] <43_1_1>: <Y_1_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_42.txt
+++ b/tests/snapshots/scip/genexpr_min_max_42.txt
@@ -9,35 +9,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= -1
- c2: +1 x_1 -1 x_4 <= -3
- c3: +1 x_2 -1 x_4 <= +2
- c4: +1 x_3 -1 x_4 <= -4
- c5: +1 x_4 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= -1;
+  [linear] <c2>: <x_1>[C] -<x_4>[C] <= -3;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 2;
+  [linear] <c4>: <x_3>[C] -<x_4>[C] <= -4;
+  [linear] <c5>: <x_4>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- max_1_0_0: +1 X_0_0 -1 max_1 <= -1
- max_1_0_1: +1 X_0_1 -1 max_1 <= +2
- max_1_1_0: +1 X_1_0 -1 max_1 <= -3
- max_1_1_1: +1 X_1_1 -1 max_1 <= -4
- 50: +1 max_1 <= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0_0>: <X_0_0>[C] -<max_1>[C] <= -1;
+  [linear] <max_1_0_1>: <X_0_1>[C] -<max_1>[C] <= 2;
+  [linear] <max_1_1_0>: <X_1_0>[C] -<max_1>[C] <= -3;
+  [linear] <max_1_1_1>: <X_1_1>[C] -<max_1>[C] <= -4;
+  [linear] <50>: <max_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_min_max_43.txt
+++ b/tests/snapshots/scip/genexpr_min_max_43.txt
@@ -9,35 +9,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_4 <= +0
- c3: +1 x_2 -1 x_4 <= +0
- c4: +1 x_3 -1 x_4 <= +0
- c5: +1 x_4 <= -3
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= -3;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- max_1_0_0: +1 X_0_0 -1 max_1 <= +0
- max_1_0_1: +1 X_0_1 -1 max_1 <= +0
- max_1_1_0: +1 X_1_0 -1 max_1 <= +0
- max_1_1_1: +1 X_1_1 -1 max_1 <= +0
- 58: +1 max_1 <= -3
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- max_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <max_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <max_1_0_0>: <X_0_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_0_1>: <X_0_1>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_0>: <X_1_0>[C] -<max_1>[C] <= 0;
+  [linear] <max_1_1_1>: <X_1_1>[C] -<max_1>[C] <= 0;
+  [linear] <58>: <max_1>[C] <= -3;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_00.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_00.txt
@@ -8,25 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: -1 x_1 <= +2
- c3: +1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 2;
+  [linear] <c3>: <x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- minimum_1_0: +1 minimum_1 -1 x <= +0
- minimum_1_1: +1 minimum_1 <= +2
- 6: +1 minimum_1 >= +1
-Bounds
- x free
- minimum_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0>: <minimum_1>[C] -<x>[C] <= 0;
+  [linear] <minimum_1_1>: <minimum_1>[C] <= 2;
+  [linear] <6>: <minimum_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_01.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_01.txt
@@ -9,27 +9,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1 y
-Subject to
- minimum_1_0: +1 minimum_1 -1 x <= +0
- minimum_1_1: +1 minimum_1 -1 y <= +0
- 12: +1 minimum_1 >= +1
-Bounds
- x free
- y free
- minimum_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0>: <minimum_1>[C] -<x>[C] <= 0;
+  [linear] <minimum_1_1>: <minimum_1>[C] -<y>[C] <= 0;
+  [linear] <12>: <minimum_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_02.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_02.txt
@@ -9,29 +9,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_2 <= +0
- c3: -1 x_2 <= +3
- c4: +1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 3;
+  [linear] <c4>: <x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1 y
-Subject to
- minimum_1_0: +1 minimum_1 -1 x <= +0
- minimum_1_1: +1 minimum_1 -1 y <= +0
- minimum_1_2: +1 minimum_1 <= +3
- 18: +1 minimum_1 >= +1
-Bounds
- x free
- y free
- minimum_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0>: <minimum_1>[C] -<x>[C] <= 0;
+  [linear] <minimum_1_1>: <minimum_1>[C] -<y>[C] <= 0;
+  [linear] <minimum_1_2>: <minimum_1>[C] <= 3;
+  [linear] <18>: <minimum_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_03.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_03.txt
@@ -12,14 +12,14 @@ AFTER COMPILATION
 can only convert an array of size 1 to a Python scalar
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- minimum_1_0: +1 minimum_1 <= +1
- minimum_1_1: +1 minimum_1 <= +2
- 23: +1 minimum_1 <= +1
- 27: +1 x >= +0
-Bounds
- x free
- minimum_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0>: <minimum_1>[C] <= 1;
+  [linear] <minimum_1_1>: <minimum_1>[C] <= 2;
+  [linear] <23>: <minimum_1>[C] <= 1;
+  [linear] <27>: <x>[C] >= 0;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_04.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_04.txt
@@ -8,25 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +1
- c2: -1 x_1 <= +2
- c3: +1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 1;
+  [linear] <c2>:  -<x_1>[C] <= 2;
+  [linear] <c3>: <x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- minimum_1_0: +1 minimum_1 -1 x <= +1
- minimum_1_1: +1 minimum_1 <= +2
- 33: +1 minimum_1 >= +1
-Bounds
- x free
- minimum_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0>: <minimum_1>[C] -<x>[C] <= 1;
+  [linear] <minimum_1_1>: <minimum_1>[C] <= 2;
+  [linear] <33>: <minimum_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_05.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_05.txt
@@ -8,25 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 -1 x_1 <= +0
- c2: -1 x_1 <= -1
- c3: +1 x_1 <= +2
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>: <x_1>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- maximum_1_0: +1 maximum_1 -1 x >= +0
- maximum_1_1: +1 maximum_1 >= +1
- 4: +1 maximum_1 <= +2
-Bounds
- x free
- maximum_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0>: <maximum_1>[C] -<x>[C] >= 0;
+  [linear] <maximum_1_1>: <maximum_1>[C] >= 1;
+  [linear] <4>: <maximum_1>[C] <= 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_06.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_06.txt
@@ -9,27 +9,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x +1 y
-Subject to
- maximum_1_0: +1 maximum_1 -1 x >= +0
- maximum_1_1: +1 maximum_1 -1 y >= +0
- 10: +1 maximum_1 <= +1
-Bounds
- x free
- y free
- maximum_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0>: <maximum_1>[C] -<x>[C] >= 0;
+  [linear] <maximum_1_1>: <maximum_1>[C] -<y>[C] >= 0;
+  [linear] <10>: <maximum_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_07.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_07.txt
@@ -9,29 +9,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: -1 x_2 <= -1
- c4: +1 x_2 <= +3
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>: <x_2>[C] <= 3;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x +1 y
-Subject to
- maximum_1_0: +1 maximum_1 -1 x >= +0
- maximum_1_1: +1 maximum_1 -1 y >= +0
- maximum_1_2: +1 maximum_1 >= +1
- 16: +1 maximum_1 <= +3
-Bounds
- x free
- y free
- maximum_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0>: <maximum_1>[C] -<x>[C] >= 0;
+  [linear] <maximum_1_1>: <maximum_1>[C] -<y>[C] >= 0;
+  [linear] <maximum_1_2>: <maximum_1>[C] >= 1;
+  [linear] <16>: <maximum_1>[C] <= 3;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_08.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_08.txt
@@ -12,14 +12,14 @@ AFTER COMPILATION
 can only convert an array of size 1 to a Python scalar
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- maximum_1_0: +1 maximum_1 >= +1
- maximum_1_1: +1 maximum_1 >= +2
- 21: +1 maximum_1 <= +2
- 25: +1 x <= +0
-Bounds
- x free
- maximum_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0>: <maximum_1>[C] >= 1;
+  [linear] <maximum_1_1>: <maximum_1>[C] >= 2;
+  [linear] <21>: <maximum_1>[C] <= 2;
+  [linear] <25>: <x>[C] <= 0;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_09.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_09.txt
@@ -8,25 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 -1 x_1 <= -1
- c2: -1 x_1 <= -1
- c3: +1 x_1 <= +2
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_1>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>: <x_1>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- maximum_1_0: +1 maximum_1 -1 x >= +1
- maximum_1_1: +1 maximum_1 >= +1
- 31: +1 maximum_1 <= +2
-Bounds
- x free
- maximum_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0>: <maximum_1>[C] -<x>[C] >= 1;
+  [linear] <maximum_1_1>: <maximum_1>[C] >= 1;
+  [linear] <31>: <maximum_1>[C] <= 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_10.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_10.txt
@@ -8,25 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 -1 x_1 <= +0
- c2: -1 x_1 <= +2
- c3: +1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 2;
+  [linear] <c3>: <x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 x_0 <= +0
- minimum_1_1_0: +1 minimum_1_0 <= +2
- 6_0: +1 minimum_1_0 >= +1
-Bounds
- x_0 free
- minimum_1_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<x_0>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] <= 2;
+  [linear] <6_0>: <minimum_1_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_11.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_11.txt
@@ -9,27 +9,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 y
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 x_0 <= +0
- minimum_1_1_0: +1 minimum_1_0 -1 y <= +0
- 12_0: +1 minimum_1_0 >= +1
-Bounds
- x_0 free
- y free
- minimum_1_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<x_0>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] -<y>[C] <= 0;
+  [linear] <12_0>: <minimum_1_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_12.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_12.txt
@@ -9,29 +9,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_2 <= +0
- c3: -1 x_2 <= +3
- c4: +1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 3;
+  [linear] <c4>: <x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 y
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 x_0 <= +0
- minimum_1_1_0: +1 minimum_1_0 -1 y <= +0
- minimum_1_2_0: +1 minimum_1_0 <= +3
- 18_0: +1 minimum_1_0 >= +1
-Bounds
- x_0 free
- y free
- minimum_1_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<x_0>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] -<y>[C] <= 0;
+  [linear] <minimum_1_2_0>: <minimum_1_0>[C] <= 3;
+  [linear] <18_0>: <minimum_1_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_13.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_13.txt
@@ -12,14 +12,14 @@ AFTER COMPILATION
 can only convert an array of size 1 to a Python scalar
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
- minimum_1_0: +1 minimum_1 <= +1
- minimum_1_1: +1 minimum_1 <= +2
- 23: +1 minimum_1 <= +1
- 27_0: +1 x_0 >= +0
-Bounds
- x_0 free
- minimum_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0>: <minimum_1>[C] <= 1;
+  [linear] <minimum_1_1>: <minimum_1>[C] <= 2;
+  [linear] <23>: <minimum_1>[C] <= 1;
+  [linear] <27_0>: <x_0>[C] >= 0;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_14.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_14.txt
@@ -8,25 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 -1 x_1 <= +0
- c2: -1 x_1 <= -1
- c3: +1 x_1 <= +2
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>: <x_1>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 x_0 >= +0
- maximum_1_1_0: +1 maximum_1_0 >= +1
- 4_0: +1 maximum_1_0 <= +2
-Bounds
- x_0 free
- maximum_1_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<x_0>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] >= 1;
+  [linear] <4_0>: <maximum_1_0>[C] <= 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_15.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_15.txt
@@ -9,27 +9,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: +1 x_2 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 y
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 x_0 >= +0
- maximum_1_1_0: +1 maximum_1_0 -1 y >= +0
- 10_0: +1 maximum_1_0 <= +1
-Bounds
- x_0 free
- y free
- maximum_1_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<x_0>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] -<y>[C] >= 0;
+  [linear] <10_0>: <maximum_1_0>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_16.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_16.txt
@@ -9,29 +9,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: -1 x_2 <= -1
- c4: +1 x_2 <= +3
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>: <x_2>[C] <= 3;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 y
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 x_0 >= +0
- maximum_1_1_0: +1 maximum_1_0 -1 y >= +0
- maximum_1_2_0: +1 maximum_1_0 >= +1
- 16_0: +1 maximum_1_0 <= +3
-Bounds
- x_0 free
- y free
- maximum_1_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<x_0>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] -<y>[C] >= 0;
+  [linear] <maximum_1_2_0>: <maximum_1_0>[C] >= 1;
+  [linear] <16_0>: <maximum_1_0>[C] <= 3;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_17.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_17.txt
@@ -12,14 +12,14 @@ AFTER COMPILATION
 can only convert an array of size 1 to a Python scalar
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
- maximum_1_0: +1 maximum_1 >= +1
- maximum_1_1: +1 maximum_1 >= +2
- 21: +1 maximum_1 <= +2
- 25_0: +1 x_0 <= +0
-Bounds
- x_0 free
- maximum_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0>: <maximum_1>[C] >= 1;
+  [linear] <maximum_1_1>: <maximum_1>[C] >= 2;
+  [linear] <21>: <maximum_1>[C] <= 2;
+  [linear] <25_0>: <x_0>[C] <= 0;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_18.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_18.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +0
- c2: -1 x_1 -1 x_3 <= +0
- c3: -1 x_2 <= +2
- c4: -1 x_3 <= -1
- c5: +1 x_2 <= +1
- c6: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 2;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+  [linear] <c5>: <x_2>[C] <= 1;
+  [linear] <c6>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 X_0 <= +0
- minimum_1_0_1: +1 minimum_1_1 -1 X_1 <= +0
- minimum_1_1_0: +1 minimum_1_0 <= +2
- minimum_1_1_1: +1 minimum_1_1 <= -1
- 9_0: +1 minimum_1_0 >= -1
- 9_1: +1 minimum_1_1 >= -1
-Bounds
- X_0 free
- X_1 free
- minimum_1_0 free
- minimum_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<X_0>[C] <= 0;
+  [linear] <minimum_1_0_1>: <minimum_1_1>[C] -<X_1>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] <= 2;
+  [linear] <minimum_1_1_1>: <minimum_1_1>[C] <= -1;
+  [linear] <9_0>: <minimum_1_0>[C] >= -1;
+  [linear] <9_1>: <minimum_1_1>[C] >= -1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_19.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_19.txt
@@ -9,39 +9,39 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +0
- c2: -1 x_1 -1 x_5 <= +0
- c3: -1 x_2 -1 x_4 <= +0
- c4: -1 x_3 -1 x_5 <= +0
- c5: +1 x_4 <= -1
- c6: +1 x_5 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= -1;
+  [linear] <c6>: <x_5>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1 +1 Y_0 +1 Y_1
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 X_0 <= +0
- minimum_1_0_1: +1 minimum_1_1 -1 X_1 <= +0
- minimum_1_1_0: +1 minimum_1_0 -1 Y_0 <= +0
- minimum_1_1_1: +1 minimum_1_1 -1 Y_1 <= +0
- 17_0: +1 minimum_1_0 >= +1
- 17_1: +1 minimum_1_1 >= +1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- minimum_1_0 free
- minimum_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<X_0>[C] <= 0;
+  [linear] <minimum_1_0_1>: <minimum_1_1>[C] -<X_1>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] -<Y_0>[C] <= 0;
+  [linear] <minimum_1_1_1>: <minimum_1_1>[C] -<Y_1>[C] <= 0;
+  [linear] <17_0>: <minimum_1_0>[C] >= 1;
+  [linear] <17_1>: <minimum_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_20.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_20.txt
@@ -9,39 +9,39 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +0
- c2: -1 x_1 -1 x_5 <= +0
- c3: -1 x_2 -1 x_4 <= +0
- c4: -1 x_3 -1 x_5 <= +0
- c5: +1 x_4 <= -2
- c6: +1 x_5 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= -2;
+  [linear] <c6>: <x_5>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1 +1 Y_0 +1 Y_1
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 X_0 <= +0
- minimum_1_0_1: +1 minimum_1_1 -1 X_1 <= +0
- minimum_1_1_0: +1 minimum_1_0 -1 Y_0 <= +0
- minimum_1_1_1: +1 minimum_1_1 -1 Y_1 <= +0
- 24_0: +1 minimum_1_0 >= +2
- 24_1: +1 minimum_1_1 >= -1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- minimum_1_0 free
- minimum_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<X_0>[C] <= 0;
+  [linear] <minimum_1_0_1>: <minimum_1_1>[C] -<X_1>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] -<Y_0>[C] <= 0;
+  [linear] <minimum_1_1_1>: <minimum_1_1>[C] -<Y_1>[C] <= 0;
+  [linear] <24_0>: <minimum_1_0>[C] >= 2;
+  [linear] <24_1>: <minimum_1_1>[C] >= -1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_21.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_21.txt
@@ -9,43 +9,43 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +0
- c2: -1 x_1 -1 x_5 <= +0
- c3: -1 x_2 -1 x_4 <= +0
- c4: -1 x_3 -1 x_5 <= +0
- c5: -1 x_4 <= +2
- c6: -1 x_5 <= -1
- c7: +1 x_4 <= +1
- c8: +1 x_5 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c5>:  -<x_4>[C] <= 2;
+  [linear] <c6>:  -<x_5>[C] <= -1;
+  [linear] <c7>: <x_4>[C] <= 1;
+  [linear] <c8>: <x_5>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1 +1 Y_0 +1 Y_1
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 X_0 <= +0
- minimum_1_0_1: +1 minimum_1_1 -1 X_1 <= +0
- minimum_1_1_0: +1 minimum_1_0 -1 Y_0 <= +0
- minimum_1_1_1: +1 minimum_1_1 -1 Y_1 <= +0
- minimum_1_2_0: +1 minimum_1_0 <= +2
- minimum_1_2_1: +1 minimum_1_1 <= -1
- 32_0: +1 minimum_1_0 >= -1
- 32_1: +1 minimum_1_1 >= -1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- minimum_1_0 free
- minimum_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<X_0>[C] <= 0;
+  [linear] <minimum_1_0_1>: <minimum_1_1>[C] -<X_1>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] -<Y_0>[C] <= 0;
+  [linear] <minimum_1_1_1>: <minimum_1_1>[C] -<Y_1>[C] <= 0;
+  [linear] <minimum_1_2_0>: <minimum_1_0>[C] <= 2;
+  [linear] <minimum_1_2_1>: <minimum_1_1>[C] <= -1;
+  [linear] <32_0>: <minimum_1_0>[C] >= -1;
+  [linear] <32_1>: <minimum_1_1>[C] >= -1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_22.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_22.txt
@@ -10,43 +10,43 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_4 = +1
- c2: +1 x_5 = +1
- c3: -1 x_0 -1 x_2 <= +0
- c4: -1 x_1 -1 x_3 <= +0
- c5: -1 x_2 <= +2
- c6: -1 x_3 <= -1
- c7: +1 x_2 -1 x_4 <= +0
- c8: +1 x_3 -1 x_5 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_4>[C] == 1;
+  [linear] <c2>: <x_5>[C] == 1;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_2>[C] <= 2;
+  [linear] <c6>:  -<x_3>[C] <= -1;
+  [linear] <c7>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c8>: <x_3>[C] -<x_5>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 X_0 <= +0
- minimum_1_0_1: +1 minimum_1_1 -1 X_1 <= +0
- minimum_1_1_0: +1 minimum_1_0 <= +2
- minimum_1_1_1: +1 minimum_1_1 <= -1
- 39_0: +1 minimum_1_0 +1 Y_0 >= +0
- 39_1: +1 minimum_1_1 +1 Y_1 >= +0
- 44_0: +1 Y_0 = +1
- 44_1: +1 Y_1 = +1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- minimum_1_0 free
- minimum_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<X_0>[C] <= 0;
+  [linear] <minimum_1_0_1>: <minimum_1_1>[C] -<X_1>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] <= 2;
+  [linear] <minimum_1_1_1>: <minimum_1_1>[C] <= -1;
+  [linear] <39_0>: <minimum_1_0>[C] +<Y_0>[C] >= 0;
+  [linear] <39_1>: <minimum_1_1>[C] +<Y_1>[C] >= 0;
+  [linear] <44_0>: <Y_0>[C] == 1;
+  [linear] <44_1>: <Y_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_23.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_23.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 -1 x_2 <= +2
- c2: -1 x_1 -1 x_3 <= -1
- c3: -1 x_2 <= +2
- c4: -1 x_3 <= -1
- c5: +1 x_2 <= +1
- c6: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_2>[C] <= 2;
+  [linear] <c2>:  -<x_1>[C] -<x_3>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= 2;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+  [linear] <c5>: <x_2>[C] <= 1;
+  [linear] <c6>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 X_0 <= +2
- minimum_1_0_1: +1 minimum_1_1 -1 X_1 <= -1
- minimum_1_1_0: +1 minimum_1_0 <= +2
- minimum_1_1_1: +1 minimum_1_1 <= -1
- 52_0: +1 minimum_1_0 >= -1
- 52_1: +1 minimum_1_1 >= -1
-Bounds
- X_0 free
- X_1 free
- minimum_1_0 free
- minimum_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<X_0>[C] <= 2;
+  [linear] <minimum_1_0_1>: <minimum_1_1>[C] -<X_1>[C] <= -1;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] <= 2;
+  [linear] <minimum_1_1_1>: <minimum_1_1>[C] <= -1;
+  [linear] <52_0>: <minimum_1_0>[C] >= -1;
+  [linear] <52_1>: <minimum_1_1>[C] >= -1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_24.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_24.txt
@@ -10,43 +10,43 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_4 = +1
- c2: -1 x_0 -1 x_2 <= +0
- c3: -1 x_1 -1 x_3 <= +0
- c4: -1 x_2 -1 x_4 <= +0
- c5: -1 x_3 -1 x_4 <= +0
- c6: -1 x_2 <= +1
- c7: -1 x_3 <= +1
- c8: +1 x_2 <= +0
- c9: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_4>[C] == 1;
+  [linear] <c2>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c5>:  -<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_2>[C] <= 1;
+  [linear] <c7>:  -<x_3>[C] <= 1;
+  [linear] <c8>: <x_2>[C] <= 0;
+  [linear] <c9>: <x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0 +1 X_1
-Subject to
- minimum_1_0_0: +1 minimum_1_0 -1 X_0 <= +0
- minimum_1_0_1: +1 minimum_1_1 -1 X_1 <= +0
- minimum_1_1_0: +1 minimum_1_0 -1 z <= +0
- minimum_1_1_1: +1 minimum_1_1 -1 z <= +0
- minimum_1_2_0: +1 minimum_1_0 <= +1
- minimum_1_2_1: +1 minimum_1_1 <= +1
- 59_0: +1 minimum_1_0 >= +0
- 59_1: +1 minimum_1_1 >= +0
- 63: +1 z = +1
-Bounds
- X_0 free
- X_1 free
- z free
- minimum_1_0 free
- minimum_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <z>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0>: <minimum_1_0>[C] -<X_0>[C] <= 0;
+  [linear] <minimum_1_0_1>: <minimum_1_1>[C] -<X_1>[C] <= 0;
+  [linear] <minimum_1_1_0>: <minimum_1_0>[C] -<z>[C] <= 0;
+  [linear] <minimum_1_1_1>: <minimum_1_1>[C] -<z>[C] <= 0;
+  [linear] <minimum_1_2_0>: <minimum_1_0>[C] <= 1;
+  [linear] <minimum_1_2_1>: <minimum_1_1>[C] <= 1;
+  [linear] <59_0>: <minimum_1_0>[C] >= 0;
+  [linear] <59_1>: <minimum_1_1>[C] >= 0;
+  [linear] <63>: <z>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_25.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_25.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_3 <= +0
- c3: -1 x_2 <= -2
- c4: -1 x_3 <= +1
- c5: +1 x_2 <= +2
- c6: +1 x_3 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= -2;
+  [linear] <c4>:  -<x_3>[C] <= 1;
+  [linear] <c5>: <x_2>[C] <= 2;
+  [linear] <c6>: <x_3>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 X_0 >= +0
- maximum_1_0_1: +1 maximum_1_1 -1 X_1 >= +0
- maximum_1_1_0: +1 maximum_1_0 >= +2
- maximum_1_1_1: +1 maximum_1_1 >= -1
- 6_0: +1 maximum_1_0 <= +2
- 6_1: +1 maximum_1_1 <= +2
-Bounds
- X_0 free
- X_1 free
- maximum_1_0 free
- maximum_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<X_0>[C] >= 0;
+  [linear] <maximum_1_0_1>: <maximum_1_1>[C] -<X_1>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] >= 2;
+  [linear] <maximum_1_1_1>: <maximum_1_1>[C] >= -1;
+  [linear] <6_0>: <maximum_1_0>[C] <= 2;
+  [linear] <6_1>: <maximum_1_1>[C] <= 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_26.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_26.txt
@@ -9,39 +9,39 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_5 <= +0
- c3: +1 x_2 -1 x_4 <= +0
- c4: +1 x_3 -1 x_5 <= +0
- c5: +1 x_4 <= +1
- c6: +1 x_5 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= 1;
+  [linear] <c6>: <x_5>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1 +1 Y_0 +1 Y_1
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 X_0 >= +0
- maximum_1_0_1: +1 maximum_1_1 -1 X_1 >= +0
- maximum_1_1_0: +1 maximum_1_0 -1 Y_0 >= +0
- maximum_1_1_1: +1 maximum_1_1 -1 Y_1 >= +0
- 14_0: +1 maximum_1_0 <= +1
- 14_1: +1 maximum_1_1 <= +1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- maximum_1_0 free
- maximum_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<X_0>[C] >= 0;
+  [linear] <maximum_1_0_1>: <maximum_1_1>[C] -<X_1>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] -<Y_0>[C] >= 0;
+  [linear] <maximum_1_1_1>: <maximum_1_1>[C] -<Y_1>[C] >= 0;
+  [linear] <14_0>: <maximum_1_0>[C] <= 1;
+  [linear] <14_1>: <maximum_1_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_27.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_27.txt
@@ -9,39 +9,39 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_5 <= +0
- c3: +1 x_2 -1 x_4 <= +0
- c4: +1 x_3 -1 x_5 <= +0
- c5: +1 x_4 <= +2
- c6: +1 x_5 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= 2;
+  [linear] <c6>: <x_5>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1 +1 Y_0 +1 Y_1
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 X_0 >= +0
- maximum_1_0_1: +1 maximum_1_1 -1 X_1 >= +0
- maximum_1_1_0: +1 maximum_1_0 -1 Y_0 >= +0
- maximum_1_1_1: +1 maximum_1_1 -1 Y_1 >= +0
- 21_0: +1 maximum_1_0 <= +2
- 21_1: +1 maximum_1_1 <= -1
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- maximum_1_0 free
- maximum_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<X_0>[C] >= 0;
+  [linear] <maximum_1_0_1>: <maximum_1_1>[C] -<X_1>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] -<Y_0>[C] >= 0;
+  [linear] <maximum_1_1_1>: <maximum_1_1>[C] -<Y_1>[C] >= 0;
+  [linear] <21_0>: <maximum_1_0>[C] <= 2;
+  [linear] <21_1>: <maximum_1_1>[C] <= -1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_28.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_28.txt
@@ -9,43 +9,43 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_5 <= +0
- c3: +1 x_2 -1 x_4 <= +0
- c4: +1 x_3 -1 x_5 <= +0
- c5: -1 x_4 <= -2
- c6: -1 x_5 <= +1
- c7: +1 x_4 <= +2
- c8: +1 x_5 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_5>[C] <= 0;
+  [linear] <c5>:  -<x_4>[C] <= -2;
+  [linear] <c6>:  -<x_5>[C] <= 1;
+  [linear] <c7>: <x_4>[C] <= 2;
+  [linear] <c8>: <x_5>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1 +1 Y_0 +1 Y_1
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 X_0 >= +0
- maximum_1_0_1: +1 maximum_1_1 -1 X_1 >= +0
- maximum_1_1_0: +1 maximum_1_0 -1 Y_0 >= +0
- maximum_1_1_1: +1 maximum_1_1 -1 Y_1 >= +0
- maximum_1_2_0: +1 maximum_1_0 >= +2
- maximum_1_2_1: +1 maximum_1_1 >= -1
- 29_0: +1 maximum_1_0 <= +2
- 29_1: +1 maximum_1_1 <= +2
-Bounds
- X_0 free
- X_1 free
- Y_0 free
- Y_1 free
- maximum_1_0 free
- maximum_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<X_0>[C] >= 0;
+  [linear] <maximum_1_0_1>: <maximum_1_1>[C] -<X_1>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] -<Y_0>[C] >= 0;
+  [linear] <maximum_1_1_1>: <maximum_1_1>[C] -<Y_1>[C] >= 0;
+  [linear] <maximum_1_2_0>: <maximum_1_0>[C] >= 2;
+  [linear] <maximum_1_2_1>: <maximum_1_1>[C] >= -1;
+  [linear] <29_0>: <maximum_1_0>[C] <= 2;
+  [linear] <29_1>: <maximum_1_1>[C] <= 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_29.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_29.txt
@@ -10,43 +10,43 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_4 = +2
- c2: +1 x_5 = +2
- c3: +1 x_0 -1 x_2 <= +0
- c4: +1 x_1 -1 x_3 <= +0
- c5: -1 x_2 <= -2
- c6: -1 x_3 <= +1
- c7: +1 x_2 -1 x_4 <= +0
- c8: +1 x_3 -1 x_5 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_4>[C] == 2;
+  [linear] <c2>: <x_5>[C] == 2;
+  [linear] <c3>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>: <x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_2>[C] <= -2;
+  [linear] <c6>:  -<x_3>[C] <= 1;
+  [linear] <c7>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c8>: <x_3>[C] -<x_5>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 X_0 >= +0
- maximum_1_0_1: +1 maximum_1_1 -1 X_1 >= +0
- maximum_1_1_0: +1 maximum_1_0 >= +2
- maximum_1_1_1: +1 maximum_1_1 >= -1
- 35_0: +1 Y_0 -1 maximum_1_0 >= +0
- 35_1: +1 Y_1 -1 maximum_1_1 >= +0
- 40_0: +1 Y_0 = +2
- 40_1: +1 Y_1 = +2
-Bounds
- X_0 free
- X_1 free
- maximum_1_0 free
- maximum_1_1 free
- Y_0 free
- Y_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<X_0>[C] >= 0;
+  [linear] <maximum_1_0_1>: <maximum_1_1>[C] -<X_1>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] >= 2;
+  [linear] <maximum_1_1_1>: <maximum_1_1>[C] >= -1;
+  [linear] <35_0>: <Y_0>[C] -<maximum_1_0>[C] >= 0;
+  [linear] <35_1>: <Y_1>[C] -<maximum_1_1>[C] >= 0;
+  [linear] <40_0>: <Y_0>[C] == 2;
+  [linear] <40_1>: <Y_1>[C] == 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_30.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_30.txt
@@ -8,35 +8,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= -2
- c2: +1 x_1 -1 x_3 <= +1
- c3: -1 x_2 <= -2
- c4: -1 x_3 <= +1
- c5: +1 x_2 <= +2
- c6: +1 x_3 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= -2;
+  [linear] <c2>: <x_1>[C] -<x_3>[C] <= 1;
+  [linear] <c3>:  -<x_2>[C] <= -2;
+  [linear] <c4>:  -<x_3>[C] <= 1;
+  [linear] <c5>: <x_2>[C] <= 2;
+  [linear] <c6>: <x_3>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 X_0 >= +2
- maximum_1_0_1: +1 maximum_1_1 -1 X_1 >= -1
- maximum_1_1_0: +1 maximum_1_0 >= +2
- maximum_1_1_1: +1 maximum_1_1 >= -1
- 48_0: +1 maximum_1_0 <= +2
- 48_1: +1 maximum_1_1 <= +2
-Bounds
- X_0 free
- X_1 free
- maximum_1_0 free
- maximum_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<X_0>[C] >= 2;
+  [linear] <maximum_1_0_1>: <maximum_1_1>[C] -<X_1>[C] >= -1;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] >= 2;
+  [linear] <maximum_1_1_1>: <maximum_1_1>[C] >= -1;
+  [linear] <48_0>: <maximum_1_0>[C] <= 2;
+  [linear] <48_1>: <maximum_1_1>[C] <= 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_31.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_31.txt
@@ -10,43 +10,43 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_4 = +1
- c2: +1 x_0 -1 x_2 <= +0
- c3: +1 x_1 -1 x_3 <= +0
- c4: -1 x_2 +1 x_4 <= +0
- c5: -1 x_3 +1 x_4 <= +0
- c6: -1 x_2 <= -1
- c7: -1 x_3 <= -1
- c8: +1 x_2 <= +2
- c9: +1 x_3 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_4>[C] == 1;
+  [linear] <c2>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c3>: <x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_2>[C] +<x_4>[C] <= 0;
+  [linear] <c5>:  -<x_3>[C] +<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_2>[C] <= -1;
+  [linear] <c7>:  -<x_3>[C] <= -1;
+  [linear] <c8>: <x_2>[C] <= 2;
+  [linear] <c9>: <x_3>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0 +1 X_1
-Subject to
- maximum_1_0_0: +1 maximum_1_0 -1 X_0 >= +0
- maximum_1_0_1: +1 maximum_1_1 -1 X_1 >= +0
- maximum_1_1_0: +1 maximum_1_0 -1 z >= +0
- maximum_1_1_1: +1 maximum_1_1 -1 z >= +0
- maximum_1_2_0: +1 maximum_1_0 >= +1
- maximum_1_2_1: +1 maximum_1_1 >= +1
- 55_0: +1 maximum_1_0 <= +2
- 55_1: +1 maximum_1_1 <= +2
- 59: +1 z = +1
-Bounds
- X_0 free
- X_1 free
- z free
- maximum_1_0 free
- maximum_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <z>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0>: <maximum_1_0>[C] -<X_0>[C] >= 0;
+  [linear] <maximum_1_0_1>: <maximum_1_1>[C] -<X_1>[C] >= 0;
+  [linear] <maximum_1_1_0>: <maximum_1_0>[C] -<z>[C] >= 0;
+  [linear] <maximum_1_1_1>: <maximum_1_1>[C] -<z>[C] >= 0;
+  [linear] <maximum_1_2_0>: <maximum_1_0>[C] >= 1;
+  [linear] <maximum_1_2_1>: <maximum_1_1>[C] >= 1;
+  [linear] <55_0>: <maximum_1_0>[C] <= 2;
+  [linear] <55_1>: <maximum_1_1>[C] <= 2;
+  [linear] <59>: <z>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_32.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_32.txt
@@ -9,55 +9,55 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +0
- c2: -1 x_1 -1 x_5 <= +0
- c3: -1 x_2 -1 x_6 <= +0
- c4: -1 x_3 -1 x_7 <= +0
- c5: -1 x_4 <= +1
- c6: -1 x_5 <= +3
- c7: -1 x_6 <= -2
- c8: -1 x_7 <= +4
- c9: +1 x_4 <= +2
- c10: +1 x_5 <= +2
- c11: +1 x_6 <= +2
- c12: +1 x_7 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_4>[C] <= 1;
+  [linear] <c6>:  -<x_5>[C] <= 3;
+  [linear] <c7>:  -<x_6>[C] <= -2;
+  [linear] <c8>:  -<x_7>[C] <= 4;
+  [linear] <c9>: <x_4>[C] <= 2;
+  [linear] <c10>: <x_5>[C] <= 2;
+  [linear] <c11>: <x_6>[C] <= 2;
+  [linear] <c12>: <x_7>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 -1 X_0_0 <= +0
- minimum_1_0_0_1: +1 minimum_1_0_1 -1 X_0_1 <= +0
- minimum_1_0_1_0: +1 minimum_1_1_0 -1 X_1_0 <= +0
- minimum_1_0_1_1: +1 minimum_1_1_1 -1 X_1_1 <= +0
- minimum_1_1_0_0: +1 minimum_1_0_0 <= +1
- minimum_1_1_0_1: +1 minimum_1_0_1 <= -2
- minimum_1_1_1_0: +1 minimum_1_1_0 <= +3
- minimum_1_1_1_1: +1 minimum_1_1_1 <= +4
- 8_0_0: +1 minimum_1_0_0 >= -2
- 8_0_1: +1 minimum_1_0_1 >= -2
- 8_1_0: +1 minimum_1_1_0 >= -2
- 8_1_1: +1 minimum_1_1_1 >= -2
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] -<X_0_0>[C] <= 0;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] -<X_0_1>[C] <= 0;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] -<X_1_0>[C] <= 0;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] -<X_1_1>[C] <= 0;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] <= 1;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] <= -2;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] <= 3;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] <= 4;
+  [linear] <8_0_0>: <minimum_1_0_0>[C] >= -2;
+  [linear] <8_0_1>: <minimum_1_0_1>[C] >= -2;
+  [linear] <8_1_0>: <minimum_1_1_0>[C] >= -2;
+  [linear] <8_1_1>: <minimum_1_1_1>[C] >= -2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_33.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_33.txt
@@ -9,63 +9,63 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5 +1 x_6 +1 x_7
-Subject to
- c1: -1 x_0 -1 x_8 <= +0
- c2: -1 x_1 -1 x_9 <= +0
- c3: -1 x_2 -1 x_10 <= +0
- c4: -1 x_3 -1 x_11 <= +0
- c5: -1 x_4 -1 x_8 <= +0
- c6: -1 x_5 -1 x_9 <= +0
- c7: -1 x_6 -1 x_10 <= +0
- c8: -1 x_7 -1 x_11 <= +0
- c9: +1 x_8 <= -1
- c10: +1 x_9 <= -1
- c11: +1 x_10 <= -1
- c12: +1 x_11 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_8>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_9>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_10>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_11>[C] <= 0;
+  [linear] <c5>:  -<x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>:  -<x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c7>:  -<x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c8>:  -<x_7>[C] -<x_11>[C] <= 0;
+  [linear] <c9>: <x_8>[C] <= -1;
+  [linear] <c10>: <x_9>[C] <= -1;
+  [linear] <c11>: <x_10>[C] <= -1;
+  [linear] <c12>: <x_11>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1 +1 Y_0_0 +1 Y_0_1 +1 Y_1_0 +1 Y_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 -1 X_0_0 <= +0
- minimum_1_0_0_1: +1 minimum_1_0_1 -1 X_0_1 <= +0
- minimum_1_0_1_0: +1 minimum_1_1_0 -1 X_1_0 <= +0
- minimum_1_0_1_1: +1 minimum_1_1_1 -1 X_1_1 <= +0
- minimum_1_1_0_0: +1 minimum_1_0_0 -1 Y_0_0 <= +0
- minimum_1_1_0_1: +1 minimum_1_0_1 -1 Y_0_1 <= +0
- minimum_1_1_1_0: +1 minimum_1_1_0 -1 Y_1_0 <= +0
- minimum_1_1_1_1: +1 minimum_1_1_1 -1 Y_1_1 <= +0
- 16_0_0: +1 minimum_1_0_0 >= +1
- 16_0_1: +1 minimum_1_0_1 >= +1
- 16_1_0: +1 minimum_1_1_0 >= +1
- 16_1_1: +1 minimum_1_1_1 >= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] -<X_0_0>[C] <= 0;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] -<X_0_1>[C] <= 0;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] -<X_1_0>[C] <= 0;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] -<X_1_1>[C] <= 0;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] -<Y_0_0>[C] <= 0;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] -<Y_0_1>[C] <= 0;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] -<Y_1_0>[C] <= 0;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] -<Y_1_1>[C] <= 0;
+  [linear] <16_0_0>: <minimum_1_0_0>[C] >= 1;
+  [linear] <16_0_1>: <minimum_1_0_1>[C] >= 1;
+  [linear] <16_1_0>: <minimum_1_1_0>[C] >= 1;
+  [linear] <16_1_1>: <minimum_1_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_34.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_34.txt
@@ -10,63 +10,63 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5 +1 x_6 +1 x_7
-Subject to
- c1: -1 x_0 -1 x_8 <= +0
- c2: -1 x_1 -1 x_9 <= +0
- c3: -1 x_2 -1 x_10 <= +0
- c4: -1 x_3 -1 x_11 <= +0
- c5: -1 x_4 -1 x_8 <= +0
- c6: -1 x_5 -1 x_9 <= +0
- c7: -1 x_6 -1 x_10 <= +0
- c8: -1 x_7 -1 x_11 <= +0
- c9: +1 x_8 <= -1
- c10: +1 x_9 <= -3
- c11: +1 x_10 <= +2
- c12: +1 x_11 <= -4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_8>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_9>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_10>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_11>[C] <= 0;
+  [linear] <c5>:  -<x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>:  -<x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c7>:  -<x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c8>:  -<x_7>[C] -<x_11>[C] <= 0;
+  [linear] <c9>: <x_8>[C] <= -1;
+  [linear] <c10>: <x_9>[C] <= -3;
+  [linear] <c11>: <x_10>[C] <= 2;
+  [linear] <c12>: <x_11>[C] <= -4;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1 +1 Y_0_0 +1 Y_0_1 +1 Y_1_0 +1 Y_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 -1 X_0_0 <= +0
- minimum_1_0_0_1: +1 minimum_1_0_1 -1 X_0_1 <= +0
- minimum_1_0_1_0: +1 minimum_1_1_0 -1 X_1_0 <= +0
- minimum_1_0_1_1: +1 minimum_1_1_1 -1 X_1_1 <= +0
- minimum_1_1_0_0: +1 minimum_1_0_0 -1 Y_0_0 <= +0
- minimum_1_1_0_1: +1 minimum_1_0_1 -1 Y_0_1 <= +0
- minimum_1_1_1_0: +1 minimum_1_1_0 -1 Y_1_0 <= +0
- minimum_1_1_1_1: +1 minimum_1_1_1 -1 Y_1_1 <= +0
- 23_0_0: +1 minimum_1_0_0 >= +1
- 23_0_1: +1 minimum_1_0_1 >= -2
- 23_1_0: +1 minimum_1_1_0 >= +3
- 23_1_1: +1 minimum_1_1_1 >= +4
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] -<X_0_0>[C] <= 0;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] -<X_0_1>[C] <= 0;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] -<X_1_0>[C] <= 0;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] -<X_1_1>[C] <= 0;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] -<Y_0_0>[C] <= 0;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] -<Y_0_1>[C] <= 0;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] -<Y_1_0>[C] <= 0;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] -<Y_1_1>[C] <= 0;
+  [linear] <23_0_0>: <minimum_1_0_0>[C] >= 1;
+  [linear] <23_0_1>: <minimum_1_0_1>[C] >= -2;
+  [linear] <23_1_0>: <minimum_1_1_0>[C] >= 3;
+  [linear] <23_1_1>: <minimum_1_1_1>[C] >= 4;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_35.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_35.txt
@@ -10,71 +10,71 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5 +1 x_6 +1 x_7
-Subject to
- c1: -1 x_0 -1 x_8 <= +0
- c2: -1 x_1 -1 x_9 <= +0
- c3: -1 x_2 -1 x_10 <= +0
- c4: -1 x_3 -1 x_11 <= +0
- c5: -1 x_4 -1 x_8 <= +0
- c6: -1 x_5 -1 x_9 <= +0
- c7: -1 x_6 -1 x_10 <= +0
- c8: -1 x_7 -1 x_11 <= +0
- c9: -1 x_8 <= +1
- c10: -1 x_9 <= +3
- c11: -1 x_10 <= -2
- c12: -1 x_11 <= +4
- c13: +1 x_8 <= +2
- c14: +1 x_9 <= +2
- c15: +1 x_10 <= +2
- c16: +1 x_11 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_8>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] -<x_9>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] -<x_10>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] -<x_11>[C] <= 0;
+  [linear] <c5>:  -<x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>:  -<x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c7>:  -<x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c8>:  -<x_7>[C] -<x_11>[C] <= 0;
+  [linear] <c9>:  -<x_8>[C] <= 1;
+  [linear] <c10>:  -<x_9>[C] <= 3;
+  [linear] <c11>:  -<x_10>[C] <= -2;
+  [linear] <c12>:  -<x_11>[C] <= 4;
+  [linear] <c13>: <x_8>[C] <= 2;
+  [linear] <c14>: <x_9>[C] <= 2;
+  [linear] <c15>: <x_10>[C] <= 2;
+  [linear] <c16>: <x_11>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1 +1 Y_0_0 +1 Y_0_1 +1 Y_1_0 +1 Y_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 -1 X_0_0 <= +0
- minimum_1_0_0_1: +1 minimum_1_0_1 -1 X_0_1 <= +0
- minimum_1_0_1_0: +1 minimum_1_1_0 -1 X_1_0 <= +0
- minimum_1_0_1_1: +1 minimum_1_1_1 -1 X_1_1 <= +0
- minimum_1_1_0_0: +1 minimum_1_0_0 -1 Y_0_0 <= +0
- minimum_1_1_0_1: +1 minimum_1_0_1 -1 Y_0_1 <= +0
- minimum_1_1_1_0: +1 minimum_1_1_0 -1 Y_1_0 <= +0
- minimum_1_1_1_1: +1 minimum_1_1_1 -1 Y_1_1 <= +0
- minimum_1_2_0_0: +1 minimum_1_0_0 <= +1
- minimum_1_2_0_1: +1 minimum_1_0_1 <= -2
- minimum_1_2_1_0: +1 minimum_1_1_0 <= +3
- minimum_1_2_1_1: +1 minimum_1_1_1 <= +4
- 31_0_0: +1 minimum_1_0_0 >= -2
- 31_0_1: +1 minimum_1_0_1 >= -2
- 31_1_0: +1 minimum_1_1_0 >= -2
- 31_1_1: +1 minimum_1_1_1 >= -2
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] -<X_0_0>[C] <= 0;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] -<X_0_1>[C] <= 0;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] -<X_1_0>[C] <= 0;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] -<X_1_1>[C] <= 0;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] -<Y_0_0>[C] <= 0;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] -<Y_0_1>[C] <= 0;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] -<Y_1_0>[C] <= 0;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] -<Y_1_1>[C] <= 0;
+  [linear] <minimum_1_2_0_0>: <minimum_1_0_0>[C] <= 1;
+  [linear] <minimum_1_2_0_1>: <minimum_1_0_1>[C] <= -2;
+  [linear] <minimum_1_2_1_0>: <minimum_1_1_0>[C] <= 3;
+  [linear] <minimum_1_2_1_1>: <minimum_1_1_1>[C] <= 4;
+  [linear] <31_0_0>: <minimum_1_0_0>[C] >= -2;
+  [linear] <31_0_1>: <minimum_1_0_1>[C] >= -2;
+  [linear] <31_1_0>: <minimum_1_1_0>[C] >= -2;
+  [linear] <31_1_1>: <minimum_1_1_1>[C] >= -2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_36.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_36.txt
@@ -11,71 +11,71 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: +1 x_8 = +2
- c2: +1 x_9 = +2
- c3: +1 x_10 = +2
- c4: +1 x_11 = +2
- c5: -1 x_0 -1 x_4 <= +0
- c6: -1 x_1 -1 x_5 <= +0
- c7: -1 x_2 -1 x_6 <= +0
- c8: -1 x_3 -1 x_7 <= +0
- c9: -1 x_4 <= +1
- c10: -1 x_5 <= +3
- c11: -1 x_6 <= -2
- c12: -1 x_7 <= +4
- c13: +1 x_4 -1 x_8 <= +0
- c14: +1 x_5 -1 x_9 <= +0
- c15: +1 x_6 -1 x_10 <= +0
- c16: +1 x_7 -1 x_11 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_8>[C] == 2;
+  [linear] <c2>: <x_9>[C] == 2;
+  [linear] <c3>: <x_10>[C] == 2;
+  [linear] <c4>: <x_11>[C] == 2;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c9>:  -<x_4>[C] <= 1;
+  [linear] <c10>:  -<x_5>[C] <= 3;
+  [linear] <c11>:  -<x_6>[C] <= -2;
+  [linear] <c12>:  -<x_7>[C] <= 4;
+  [linear] <c13>: <x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c14>: <x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c15>: <x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c16>: <x_7>[C] -<x_11>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 -1 X_0_0 <= +0
- minimum_1_0_0_1: +1 minimum_1_0_1 -1 X_0_1 <= +0
- minimum_1_0_1_0: +1 minimum_1_1_0 -1 X_1_0 <= +0
- minimum_1_0_1_1: +1 minimum_1_1_1 -1 X_1_1 <= +0
- minimum_1_1_0_0: +1 minimum_1_0_0 <= +1
- minimum_1_1_0_1: +1 minimum_1_0_1 <= -2
- minimum_1_1_1_0: +1 minimum_1_1_0 <= +3
- minimum_1_1_1_1: +1 minimum_1_1_1 <= +4
- 38_0_0: +1 minimum_1_0_0 +1 Y_0_0 >= +0
- 38_0_1: +1 minimum_1_0_1 +1 Y_0_1 >= +0
- 38_1_0: +1 minimum_1_1_0 +1 Y_1_0 >= +0
- 38_1_1: +1 minimum_1_1_1 +1 Y_1_1 >= +0
- 43_0_0: +1 Y_0_0 = +2
- 43_0_1: +1 Y_0_1 = +2
- 43_1_0: +1 Y_1_0 = +2
- 43_1_1: +1 Y_1_1 = +2
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] -<X_0_0>[C] <= 0;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] -<X_0_1>[C] <= 0;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] -<X_1_0>[C] <= 0;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] -<X_1_1>[C] <= 0;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] <= 1;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] <= -2;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] <= 3;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] <= 4;
+  [linear] <38_0_0>: <minimum_1_0_0>[C] +<Y_0_0>[C] >= 0;
+  [linear] <38_0_1>: <minimum_1_0_1>[C] +<Y_0_1>[C] >= 0;
+  [linear] <38_1_0>: <minimum_1_1_0>[C] +<Y_1_0>[C] >= 0;
+  [linear] <38_1_1>: <minimum_1_1_1>[C] +<Y_1_1>[C] >= 0;
+  [linear] <43_0_0>: <Y_0_0>[C] == 2;
+  [linear] <43_0_1>: <Y_0_1>[C] == 2;
+  [linear] <43_1_0>: <Y_1_0>[C] == 2;
+  [linear] <43_1_1>: <Y_1_1>[C] == 2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_37.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_37.txt
@@ -14,32 +14,32 @@ AFTER COMPILATION
 cannot reshape array of size 0 into shape (2,2)
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 <= +1
- minimum_1_0_0_1: +1 minimum_1_0_1 <= -2
- minimum_1_0_1_0: +1 minimum_1_1_0 <= +3
- minimum_1_0_1_1: +1 minimum_1_1_1 <= +4
- minimum_1_1_0_0: +1 minimum_1_0_0 <= +2
- minimum_1_1_0_1: +1 minimum_1_0_1 <= -1
- minimum_1_1_1_0: +1 minimum_1_1_0 <= +1
- minimum_1_1_1_1: +1 minimum_1_1_1 <= +3
- 50_0_0: +1 minimum_1_0_0 >= -2
- 50_0_1: +1 minimum_1_0_1 >= -2
- 50_1_0: +1 minimum_1_1_0 >= -2
- 50_1_1: +1 minimum_1_1_1 >= -2
- 55_0_0: +1 X_0_0 = +1
- 55_0_1: +1 X_0_1 = +1
- 55_1_0: +1 X_1_0 = +1
- 55_1_1: +1 X_1_1 = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] <= 1;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] <= -2;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] <= 3;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] <= 4;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] <= 2;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] <= -1;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] <= 1;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] <= 3;
+  [linear] <50_0_0>: <minimum_1_0_0>[C] >= -2;
+  [linear] <50_0_1>: <minimum_1_0_1>[C] >= -2;
+  [linear] <50_1_0>: <minimum_1_1_0>[C] >= -2;
+  [linear] <50_1_1>: <minimum_1_1_1>[C] >= -2;
+  [linear] <55_0_0>: <X_0_0>[C] == 1;
+  [linear] <55_0_1>: <X_0_1>[C] == 1;
+  [linear] <55_1_0>: <X_1_0>[C] == 1;
+  [linear] <55_1_1>: <X_1_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_38.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_38.txt
@@ -10,55 +10,55 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 -1 x_4 <= +1
- c2: -1 x_1 -1 x_5 <= +3
- c3: -1 x_2 -1 x_6 <= -2
- c4: -1 x_3 -1 x_7 <= +4
- c5: -1 x_4 <= +1
- c6: -1 x_5 <= +3
- c7: -1 x_6 <= -2
- c8: -1 x_7 <= +4
- c9: +1 x_4 <= +2
- c10: +1 x_5 <= +2
- c11: +1 x_6 <= +2
- c12: +1 x_7 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] -<x_4>[C] <= 1;
+  [linear] <c2>:  -<x_1>[C] -<x_5>[C] <= 3;
+  [linear] <c3>:  -<x_2>[C] -<x_6>[C] <= -2;
+  [linear] <c4>:  -<x_3>[C] -<x_7>[C] <= 4;
+  [linear] <c5>:  -<x_4>[C] <= 1;
+  [linear] <c6>:  -<x_5>[C] <= 3;
+  [linear] <c7>:  -<x_6>[C] <= -2;
+  [linear] <c8>:  -<x_7>[C] <= 4;
+  [linear] <c9>: <x_4>[C] <= 2;
+  [linear] <c10>: <x_5>[C] <= 2;
+  [linear] <c11>: <x_6>[C] <= 2;
+  [linear] <c12>: <x_7>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 -1 X_0_0 <= +1
- minimum_1_0_0_1: +1 minimum_1_0_1 -1 X_0_1 <= -2
- minimum_1_0_1_0: +1 minimum_1_1_0 -1 X_1_0 <= +3
- minimum_1_0_1_1: +1 minimum_1_1_1 -1 X_1_1 <= +4
- minimum_1_1_0_0: +1 minimum_1_0_0 <= +1
- minimum_1_1_0_1: +1 minimum_1_0_1 <= -2
- minimum_1_1_1_0: +1 minimum_1_1_0 <= +3
- minimum_1_1_1_1: +1 minimum_1_1_1 <= +4
- 63_0_0: +1 minimum_1_0_0 >= -2
- 63_0_1: +1 minimum_1_0_1 >= -2
- 63_1_0: +1 minimum_1_1_0 >= -2
- 63_1_1: +1 minimum_1_1_1 >= -2
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] -<X_0_0>[C] <= 1;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] -<X_0_1>[C] <= -2;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] -<X_1_0>[C] <= 3;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] -<X_1_1>[C] <= 4;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] <= 1;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] <= -2;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] <= 3;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] <= 4;
+  [linear] <63_0_0>: <minimum_1_0_0>[C] >= -2;
+  [linear] <63_0_1>: <minimum_1_0_1>[C] >= -2;
+  [linear] <63_1_0>: <minimum_1_1_0>[C] >= -2;
+  [linear] <63_1_1>: <minimum_1_1_1>[C] >= -2;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_39.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_39.txt
@@ -10,67 +10,67 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: +1 x_8 = +1
- c2: -1 x_0 -1 x_4 <= +0
- c3: -1 x_1 -1 x_5 <= +0
- c4: -1 x_2 -1 x_6 <= +0
- c5: -1 x_3 -1 x_7 <= +0
- c6: -1 x_4 -1 x_8 <= +0
- c7: -1 x_5 -1 x_8 <= +0
- c8: -1 x_6 -1 x_8 <= +0
- c9: -1 x_7 -1 x_8 <= +0
- c10: -1 x_4 <= +1
- c11: -1 x_5 <= +1
- c12: -1 x_6 <= +1
- c13: -1 x_7 <= +1
- c14: +1 x_4 <= +0
- c15: +1 x_5 <= +0
- c16: +1 x_6 <= +0
- c17: +1 x_7 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_8>[C] == 1;
+  [linear] <c2>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c3>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c4>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c5>:  -<x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c6>:  -<x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c7>:  -<x_5>[C] -<x_8>[C] <= 0;
+  [linear] <c8>:  -<x_6>[C] -<x_8>[C] <= 0;
+  [linear] <c9>:  -<x_7>[C] -<x_8>[C] <= 0;
+  [linear] <c10>:  -<x_4>[C] <= 1;
+  [linear] <c11>:  -<x_5>[C] <= 1;
+  [linear] <c12>:  -<x_6>[C] <= 1;
+  [linear] <c13>:  -<x_7>[C] <= 1;
+  [linear] <c14>: <x_4>[C] <= 0;
+  [linear] <c15>: <x_5>[C] <= 0;
+  [linear] <c16>: <x_6>[C] <= 0;
+  [linear] <c17>: <x_7>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- minimum_1_0_0_0: +1 minimum_1_0_0 -1 X_0_0 <= +0
- minimum_1_0_0_1: +1 minimum_1_0_1 -1 X_0_1 <= +0
- minimum_1_0_1_0: +1 minimum_1_1_0 -1 X_1_0 <= +0
- minimum_1_0_1_1: +1 minimum_1_1_1 -1 X_1_1 <= +0
- minimum_1_1_0_0: +1 minimum_1_0_0 -1 z <= +0
- minimum_1_1_0_1: +1 minimum_1_0_1 -1 z <= +0
- minimum_1_1_1_0: +1 minimum_1_1_0 -1 z <= +0
- minimum_1_1_1_1: +1 minimum_1_1_1 -1 z <= +0
- minimum_1_2_0_0: +1 minimum_1_0_0 <= +1
- minimum_1_2_0_1: +1 minimum_1_0_1 <= +1
- minimum_1_2_1_0: +1 minimum_1_1_0 <= +1
- minimum_1_2_1_1: +1 minimum_1_1_1 <= +1
- 70_0_0: +1 minimum_1_0_0 >= +0
- 70_0_1: +1 minimum_1_0_1 >= +0
- 70_1_0: +1 minimum_1_1_0 >= +0
- 70_1_1: +1 minimum_1_1_1 >= +0
- 74: +1 z = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- z free
- minimum_1_0_0 free
- minimum_1_0_1 free
- minimum_1_1_0 free
- minimum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <z>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <minimum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <minimum_1_0_0_0>: <minimum_1_0_0>[C] -<X_0_0>[C] <= 0;
+  [linear] <minimum_1_0_0_1>: <minimum_1_0_1>[C] -<X_0_1>[C] <= 0;
+  [linear] <minimum_1_0_1_0>: <minimum_1_1_0>[C] -<X_1_0>[C] <= 0;
+  [linear] <minimum_1_0_1_1>: <minimum_1_1_1>[C] -<X_1_1>[C] <= 0;
+  [linear] <minimum_1_1_0_0>: <minimum_1_0_0>[C] -<z>[C] <= 0;
+  [linear] <minimum_1_1_0_1>: <minimum_1_0_1>[C] -<z>[C] <= 0;
+  [linear] <minimum_1_1_1_0>: <minimum_1_1_0>[C] -<z>[C] <= 0;
+  [linear] <minimum_1_1_1_1>: <minimum_1_1_1>[C] -<z>[C] <= 0;
+  [linear] <minimum_1_2_0_0>: <minimum_1_0_0>[C] <= 1;
+  [linear] <minimum_1_2_0_1>: <minimum_1_0_1>[C] <= 1;
+  [linear] <minimum_1_2_1_0>: <minimum_1_1_0>[C] <= 1;
+  [linear] <minimum_1_2_1_1>: <minimum_1_1_1>[C] <= 1;
+  [linear] <70_0_0>: <minimum_1_0_0>[C] >= 0;
+  [linear] <70_0_1>: <minimum_1_0_1>[C] >= 0;
+  [linear] <70_1_0>: <minimum_1_1_0>[C] >= 0;
+  [linear] <70_1_1>: <minimum_1_1_1>[C] >= 0;
+  [linear] <74>: <z>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_40.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_40.txt
@@ -9,55 +9,55 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_5 <= +0
- c3: +1 x_2 -1 x_6 <= +0
- c4: +1 x_3 -1 x_7 <= +0
- c5: -1 x_4 <= -1
- c6: -1 x_5 <= -3
- c7: -1 x_6 <= +2
- c8: -1 x_7 <= -4
- c9: +1 x_4 <= +4
- c10: +1 x_5 <= +4
- c11: +1 x_6 <= +4
- c12: +1 x_7 <= +4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_4>[C] <= -1;
+  [linear] <c6>:  -<x_5>[C] <= -3;
+  [linear] <c7>:  -<x_6>[C] <= 2;
+  [linear] <c8>:  -<x_7>[C] <= -4;
+  [linear] <c9>: <x_4>[C] <= 4;
+  [linear] <c10>: <x_5>[C] <= 4;
+  [linear] <c11>: <x_6>[C] <= 4;
+  [linear] <c12>: <x_7>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 -1 X_0_0 >= +0
- maximum_1_0_0_1: +1 maximum_1_0_1 -1 X_0_1 >= +0
- maximum_1_0_1_0: +1 maximum_1_1_0 -1 X_1_0 >= +0
- maximum_1_0_1_1: +1 maximum_1_1_1 -1 X_1_1 >= +0
- maximum_1_1_0_0: +1 maximum_1_0_0 >= +1
- maximum_1_1_0_1: +1 maximum_1_0_1 >= -2
- maximum_1_1_1_0: +1 maximum_1_1_0 >= +3
- maximum_1_1_1_1: +1 maximum_1_1_1 >= +4
- 6_0_0: +1 maximum_1_0_0 <= +4
- 6_0_1: +1 maximum_1_0_1 <= +4
- 6_1_0: +1 maximum_1_1_0 <= +4
- 6_1_1: +1 maximum_1_1_1 <= +4
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] -<X_0_0>[C] >= 0;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] -<X_0_1>[C] >= 0;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] -<X_1_0>[C] >= 0;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] -<X_1_1>[C] >= 0;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] >= 1;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] >= -2;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] >= 3;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] >= 4;
+  [linear] <6_0_0>: <maximum_1_0_0>[C] <= 4;
+  [linear] <6_0_1>: <maximum_1_0_1>[C] <= 4;
+  [linear] <6_1_0>: <maximum_1_1_0>[C] <= 4;
+  [linear] <6_1_1>: <maximum_1_1_1>[C] <= 4;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_41.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_41.txt
@@ -9,63 +9,63 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3 -1 x_4 -1 x_5 -1 x_6 -1 x_7
-Subject to
- c1: +1 x_0 -1 x_8 <= +0
- c2: +1 x_1 -1 x_9 <= +0
- c3: +1 x_2 -1 x_10 <= +0
- c4: +1 x_3 -1 x_11 <= +0
- c5: +1 x_4 -1 x_8 <= +0
- c6: +1 x_5 -1 x_9 <= +0
- c7: +1 x_6 -1 x_10 <= +0
- c8: +1 x_7 -1 x_11 <= +0
- c9: +1 x_8 <= +1
- c10: +1 x_9 <= +1
- c11: +1 x_10 <= +1
- c12: +1 x_11 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_8>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_9>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_10>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_11>[C] <= 0;
+  [linear] <c5>: <x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>: <x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c7>: <x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c8>: <x_7>[C] -<x_11>[C] <= 0;
+  [linear] <c9>: <x_8>[C] <= 1;
+  [linear] <c10>: <x_9>[C] <= 1;
+  [linear] <c11>: <x_10>[C] <= 1;
+  [linear] <c12>: <x_11>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1 +1 Y_0_0 +1 Y_0_1 +1 Y_1_0 +1 Y_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 -1 X_0_0 >= +0
- maximum_1_0_0_1: +1 maximum_1_0_1 -1 X_0_1 >= +0
- maximum_1_0_1_0: +1 maximum_1_1_0 -1 X_1_0 >= +0
- maximum_1_0_1_1: +1 maximum_1_1_1 -1 X_1_1 >= +0
- maximum_1_1_0_0: +1 maximum_1_0_0 -1 Y_0_0 >= +0
- maximum_1_1_0_1: +1 maximum_1_0_1 -1 Y_0_1 >= +0
- maximum_1_1_1_0: +1 maximum_1_1_0 -1 Y_1_0 >= +0
- maximum_1_1_1_1: +1 maximum_1_1_1 -1 Y_1_1 >= +0
- 14_0_0: +1 maximum_1_0_0 <= +1
- 14_0_1: +1 maximum_1_0_1 <= +1
- 14_1_0: +1 maximum_1_1_0 <= +1
- 14_1_1: +1 maximum_1_1_1 <= +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] -<X_0_0>[C] >= 0;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] -<X_0_1>[C] >= 0;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] -<X_1_0>[C] >= 0;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] -<X_1_1>[C] >= 0;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] -<Y_0_0>[C] >= 0;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] -<Y_0_1>[C] >= 0;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] -<Y_1_0>[C] >= 0;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] -<Y_1_1>[C] >= 0;
+  [linear] <14_0_0>: <maximum_1_0_0>[C] <= 1;
+  [linear] <14_0_1>: <maximum_1_0_1>[C] <= 1;
+  [linear] <14_1_0>: <maximum_1_1_0>[C] <= 1;
+  [linear] <14_1_1>: <maximum_1_1_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_42.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_42.txt
@@ -10,63 +10,63 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3 -1 x_4 -1 x_5 -1 x_6 -1 x_7
-Subject to
- c1: +1 x_0 -1 x_8 <= +0
- c2: +1 x_1 -1 x_9 <= +0
- c3: +1 x_2 -1 x_10 <= +0
- c4: +1 x_3 -1 x_11 <= +0
- c5: +1 x_4 -1 x_8 <= +0
- c6: +1 x_5 -1 x_9 <= +0
- c7: +1 x_6 -1 x_10 <= +0
- c8: +1 x_7 -1 x_11 <= +0
- c9: +1 x_8 <= +1
- c10: +1 x_9 <= +3
- c11: +1 x_10 <= -2
- c12: +1 x_11 <= +4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_8>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_9>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_10>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_11>[C] <= 0;
+  [linear] <c5>: <x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>: <x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c7>: <x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c8>: <x_7>[C] -<x_11>[C] <= 0;
+  [linear] <c9>: <x_8>[C] <= 1;
+  [linear] <c10>: <x_9>[C] <= 3;
+  [linear] <c11>: <x_10>[C] <= -2;
+  [linear] <c12>: <x_11>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1 +1 Y_0_0 +1 Y_0_1 +1 Y_1_0 +1 Y_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 -1 X_0_0 >= +0
- maximum_1_0_0_1: +1 maximum_1_0_1 -1 X_0_1 >= +0
- maximum_1_0_1_0: +1 maximum_1_1_0 -1 X_1_0 >= +0
- maximum_1_0_1_1: +1 maximum_1_1_1 -1 X_1_1 >= +0
- maximum_1_1_0_0: +1 maximum_1_0_0 -1 Y_0_0 >= +0
- maximum_1_1_0_1: +1 maximum_1_0_1 -1 Y_0_1 >= +0
- maximum_1_1_1_0: +1 maximum_1_1_0 -1 Y_1_0 >= +0
- maximum_1_1_1_1: +1 maximum_1_1_1 -1 Y_1_1 >= +0
- 21_0_0: +1 maximum_1_0_0 <= +1
- 21_0_1: +1 maximum_1_0_1 <= -2
- 21_1_0: +1 maximum_1_1_0 <= +3
- 21_1_1: +1 maximum_1_1_1 <= +4
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] -<X_0_0>[C] >= 0;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] -<X_0_1>[C] >= 0;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] -<X_1_0>[C] >= 0;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] -<X_1_1>[C] >= 0;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] -<Y_0_0>[C] >= 0;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] -<Y_0_1>[C] >= 0;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] -<Y_1_0>[C] >= 0;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] -<Y_1_1>[C] >= 0;
+  [linear] <21_0_0>: <maximum_1_0_0>[C] <= 1;
+  [linear] <21_0_1>: <maximum_1_0_1>[C] <= -2;
+  [linear] <21_1_0>: <maximum_1_1_0>[C] <= 3;
+  [linear] <21_1_1>: <maximum_1_1_1>[C] <= 4;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_43.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_43.txt
@@ -10,71 +10,71 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3 -1 x_4 -1 x_5 -1 x_6 -1 x_7
-Subject to
- c1: +1 x_0 -1 x_8 <= +0
- c2: +1 x_1 -1 x_9 <= +0
- c3: +1 x_2 -1 x_10 <= +0
- c4: +1 x_3 -1 x_11 <= +0
- c5: +1 x_4 -1 x_8 <= +0
- c6: +1 x_5 -1 x_9 <= +0
- c7: +1 x_6 -1 x_10 <= +0
- c8: +1 x_7 -1 x_11 <= +0
- c9: -1 x_8 <= -1
- c10: -1 x_9 <= -3
- c11: -1 x_10 <= +2
- c12: -1 x_11 <= -4
- c13: +1 x_8 <= +4
- c14: +1 x_9 <= +4
- c15: +1 x_10 <= +4
- c16: +1 x_11 <= +4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_8>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_9>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_10>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_11>[C] <= 0;
+  [linear] <c5>: <x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c6>: <x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c7>: <x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c8>: <x_7>[C] -<x_11>[C] <= 0;
+  [linear] <c9>:  -<x_8>[C] <= -1;
+  [linear] <c10>:  -<x_9>[C] <= -3;
+  [linear] <c11>:  -<x_10>[C] <= 2;
+  [linear] <c12>:  -<x_11>[C] <= -4;
+  [linear] <c13>: <x_8>[C] <= 4;
+  [linear] <c14>: <x_9>[C] <= 4;
+  [linear] <c15>: <x_10>[C] <= 4;
+  [linear] <c16>: <x_11>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1 +1 Y_0_0 +1 Y_0_1 +1 Y_1_0 +1 Y_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 -1 X_0_0 >= +0
- maximum_1_0_0_1: +1 maximum_1_0_1 -1 X_0_1 >= +0
- maximum_1_0_1_0: +1 maximum_1_1_0 -1 X_1_0 >= +0
- maximum_1_0_1_1: +1 maximum_1_1_1 -1 X_1_1 >= +0
- maximum_1_1_0_0: +1 maximum_1_0_0 -1 Y_0_0 >= +0
- maximum_1_1_0_1: +1 maximum_1_0_1 -1 Y_0_1 >= +0
- maximum_1_1_1_0: +1 maximum_1_1_0 -1 Y_1_0 >= +0
- maximum_1_1_1_1: +1 maximum_1_1_1 -1 Y_1_1 >= +0
- maximum_1_2_0_0: +1 maximum_1_0_0 >= +1
- maximum_1_2_0_1: +1 maximum_1_0_1 >= -2
- maximum_1_2_1_0: +1 maximum_1_1_0 >= +3
- maximum_1_2_1_1: +1 maximum_1_1_1 >= +4
- 29_0_0: +1 maximum_1_0_0 <= +4
- 29_0_1: +1 maximum_1_0_1 <= +4
- 29_1_0: +1 maximum_1_1_0 <= +4
- 29_1_1: +1 maximum_1_1_1 <= +4
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] -<X_0_0>[C] >= 0;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] -<X_0_1>[C] >= 0;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] -<X_1_0>[C] >= 0;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] -<X_1_1>[C] >= 0;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] -<Y_0_0>[C] >= 0;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] -<Y_0_1>[C] >= 0;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] -<Y_1_0>[C] >= 0;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] -<Y_1_1>[C] >= 0;
+  [linear] <maximum_1_2_0_0>: <maximum_1_0_0>[C] >= 1;
+  [linear] <maximum_1_2_0_1>: <maximum_1_0_1>[C] >= -2;
+  [linear] <maximum_1_2_1_0>: <maximum_1_1_0>[C] >= 3;
+  [linear] <maximum_1_2_1_1>: <maximum_1_1_1>[C] >= 4;
+  [linear] <29_0_0>: <maximum_1_0_0>[C] <= 4;
+  [linear] <29_0_1>: <maximum_1_0_1>[C] <= 4;
+  [linear] <29_1_0>: <maximum_1_1_0>[C] <= 4;
+  [linear] <29_1_1>: <maximum_1_1_1>[C] <= 4;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_44.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_44.txt
@@ -11,71 +11,71 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_8 = +4
- c2: +1 x_9 = +4
- c3: +1 x_10 = +4
- c4: +1 x_11 = +4
- c5: +1 x_0 -1 x_4 <= +0
- c6: +1 x_1 -1 x_5 <= +0
- c7: +1 x_2 -1 x_6 <= +0
- c8: +1 x_3 -1 x_7 <= +0
- c9: -1 x_4 <= -1
- c10: -1 x_5 <= -3
- c11: -1 x_6 <= +2
- c12: -1 x_7 <= -4
- c13: +1 x_4 -1 x_8 <= +0
- c14: +1 x_5 -1 x_9 <= +0
- c15: +1 x_6 -1 x_10 <= +0
- c16: +1 x_7 -1 x_11 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
- x_9 free
- x_10 free
- x_11 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_11>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_8>[C] == 4;
+  [linear] <c2>: <x_9>[C] == 4;
+  [linear] <c3>: <x_10>[C] == 4;
+  [linear] <c4>: <x_11>[C] == 4;
+  [linear] <c5>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>: <x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c7>: <x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c8>: <x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c9>:  -<x_4>[C] <= -1;
+  [linear] <c10>:  -<x_5>[C] <= -3;
+  [linear] <c11>:  -<x_6>[C] <= 2;
+  [linear] <c12>:  -<x_7>[C] <= -4;
+  [linear] <c13>: <x_4>[C] -<x_8>[C] <= 0;
+  [linear] <c14>: <x_5>[C] -<x_9>[C] <= 0;
+  [linear] <c15>: <x_6>[C] -<x_10>[C] <= 0;
+  [linear] <c16>: <x_7>[C] -<x_11>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 -1 X_0_0 >= +0
- maximum_1_0_0_1: +1 maximum_1_0_1 -1 X_0_1 >= +0
- maximum_1_0_1_0: +1 maximum_1_1_0 -1 X_1_0 >= +0
- maximum_1_0_1_1: +1 maximum_1_1_1 -1 X_1_1 >= +0
- maximum_1_1_0_0: +1 maximum_1_0_0 >= +1
- maximum_1_1_0_1: +1 maximum_1_0_1 >= -2
- maximum_1_1_1_0: +1 maximum_1_1_0 >= +3
- maximum_1_1_1_1: +1 maximum_1_1_1 >= +4
- 35_0_0: +1 Y_0_0 -1 maximum_1_0_0 >= +0
- 35_0_1: +1 Y_0_1 -1 maximum_1_0_1 >= +0
- 35_1_0: +1 Y_1_0 -1 maximum_1_1_0 >= +0
- 35_1_1: +1 Y_1_1 -1 maximum_1_1_1 >= +0
- 40_0_0: +1 Y_0_0 = +4
- 40_0_1: +1 Y_0_1 = +4
- 40_1_0: +1 Y_1_0 = +4
- 40_1_1: +1 Y_1_1 = +4
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
- Y_0_0 free
- Y_0_1 free
- Y_1_0 free
- Y_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <Y_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] -<X_0_0>[C] >= 0;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] -<X_0_1>[C] >= 0;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] -<X_1_0>[C] >= 0;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] -<X_1_1>[C] >= 0;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] >= 1;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] >= -2;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] >= 3;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] >= 4;
+  [linear] <35_0_0>: <Y_0_0>[C] -<maximum_1_0_0>[C] >= 0;
+  [linear] <35_0_1>: <Y_0_1>[C] -<maximum_1_0_1>[C] >= 0;
+  [linear] <35_1_0>: <Y_1_0>[C] -<maximum_1_1_0>[C] >= 0;
+  [linear] <35_1_1>: <Y_1_1>[C] -<maximum_1_1_1>[C] >= 0;
+  [linear] <40_0_0>: <Y_0_0>[C] == 4;
+  [linear] <40_0_1>: <Y_0_1>[C] == 4;
+  [linear] <40_1_0>: <Y_1_0>[C] == 4;
+  [linear] <40_1_1>: <Y_1_1>[C] == 4;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_45.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_45.txt
@@ -14,32 +14,32 @@ AFTER COMPILATION
 cannot reshape array of size 0 into shape (2,2)
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 >= +1
- maximum_1_0_0_1: +1 maximum_1_0_1 >= -2
- maximum_1_0_1_0: +1 maximum_1_1_0 >= +3
- maximum_1_0_1_1: +1 maximum_1_1_1 >= +4
- maximum_1_1_0_0: +1 maximum_1_0_0 >= +2
- maximum_1_1_0_1: +1 maximum_1_0_1 >= -1
- maximum_1_1_1_0: +1 maximum_1_1_0 >= +1
- maximum_1_1_1_1: +1 maximum_1_1_1 >= +3
- 47_0_0: +1 maximum_1_0_0 <= +4
- 47_0_1: +1 maximum_1_0_1 <= +4
- 47_1_0: +1 maximum_1_1_0 <= +4
- 47_1_1: +1 maximum_1_1_1 <= +4
- 52_0_0: +1 X_0_0 = +1
- 52_0_1: +1 X_0_1 = +1
- 52_1_0: +1 X_1_0 = +1
- 52_1_1: +1 X_1_1 = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] >= 1;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] >= -2;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] >= 3;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] >= 4;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] >= 2;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] >= -1;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] >= 1;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] >= 3;
+  [linear] <47_0_0>: <maximum_1_0_0>[C] <= 4;
+  [linear] <47_0_1>: <maximum_1_0_1>[C] <= 4;
+  [linear] <47_1_0>: <maximum_1_1_0>[C] <= 4;
+  [linear] <47_1_1>: <maximum_1_1_1>[C] <= 4;
+  [linear] <52_0_0>: <X_0_0>[C] == 1;
+  [linear] <52_0_1>: <X_0_1>[C] == 1;
+  [linear] <52_1_0>: <X_1_0>[C] == 1;
+  [linear] <52_1_1>: <X_1_1>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_46.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_46.txt
@@ -10,55 +10,55 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= -1
- c2: +1 x_1 -1 x_5 <= -3
- c3: +1 x_2 -1 x_6 <= +2
- c4: +1 x_3 -1 x_7 <= -4
- c5: -1 x_4 <= -1
- c6: -1 x_5 <= -3
- c7: -1 x_6 <= +2
- c8: -1 x_7 <= -4
- c9: +1 x_4 <= +4
- c10: +1 x_5 <= +4
- c11: +1 x_6 <= +4
- c12: +1 x_7 <= +4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= -1;
+  [linear] <c2>: <x_1>[C] -<x_5>[C] <= -3;
+  [linear] <c3>: <x_2>[C] -<x_6>[C] <= 2;
+  [linear] <c4>: <x_3>[C] -<x_7>[C] <= -4;
+  [linear] <c5>:  -<x_4>[C] <= -1;
+  [linear] <c6>:  -<x_5>[C] <= -3;
+  [linear] <c7>:  -<x_6>[C] <= 2;
+  [linear] <c8>:  -<x_7>[C] <= -4;
+  [linear] <c9>: <x_4>[C] <= 4;
+  [linear] <c10>: <x_5>[C] <= 4;
+  [linear] <c11>: <x_6>[C] <= 4;
+  [linear] <c12>: <x_7>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 -1 X_0_0 >= +1
- maximum_1_0_0_1: +1 maximum_1_0_1 -1 X_0_1 >= -2
- maximum_1_0_1_0: +1 maximum_1_1_0 -1 X_1_0 >= +3
- maximum_1_0_1_1: +1 maximum_1_1_1 -1 X_1_1 >= +4
- maximum_1_1_0_0: +1 maximum_1_0_0 >= +1
- maximum_1_1_0_1: +1 maximum_1_0_1 >= -2
- maximum_1_1_1_0: +1 maximum_1_1_0 >= +3
- maximum_1_1_1_1: +1 maximum_1_1_1 >= +4
- 60_0_0: +1 maximum_1_0_0 <= +4
- 60_0_1: +1 maximum_1_0_1 <= +4
- 60_1_0: +1 maximum_1_1_0 <= +4
- 60_1_1: +1 maximum_1_1_1 <= +4
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] -<X_0_0>[C] >= 1;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] -<X_0_1>[C] >= -2;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] -<X_1_0>[C] >= 3;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] -<X_1_1>[C] >= 4;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] >= 1;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] >= -2;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] >= 3;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] >= 4;
+  [linear] <60_0_0>: <maximum_1_0_0>[C] <= 4;
+  [linear] <60_0_1>: <maximum_1_0_1>[C] <= 4;
+  [linear] <60_1_0>: <maximum_1_1_0>[C] <= 4;
+  [linear] <60_1_1>: <maximum_1_1_1>[C] <= 4;
+END

--- a/tests/snapshots/scip/genexpr_minimum_maximum_47.txt
+++ b/tests/snapshots/scip/genexpr_minimum_maximum_47.txt
@@ -10,67 +10,67 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_8 = +1
- c2: +1 x_0 -1 x_4 <= +0
- c3: +1 x_1 -1 x_5 <= +0
- c4: +1 x_2 -1 x_6 <= +0
- c5: +1 x_3 -1 x_7 <= +0
- c6: -1 x_4 +1 x_8 <= +0
- c7: -1 x_5 +1 x_8 <= +0
- c8: -1 x_6 +1 x_8 <= +0
- c9: -1 x_7 +1 x_8 <= +0
- c10: -1 x_4 <= -1
- c11: -1 x_5 <= -1
- c12: -1 x_6 <= -1
- c13: -1 x_7 <= -1
- c14: +1 x_4 <= +2
- c15: +1 x_5 <= +2
- c16: +1 x_6 <= +2
- c17: +1 x_7 <= +2
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- x_8 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_8>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_8>[C] == 1;
+  [linear] <c2>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c3>: <x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c4>: <x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c5>: <x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c6>:  -<x_4>[C] +<x_8>[C] <= 0;
+  [linear] <c7>:  -<x_5>[C] +<x_8>[C] <= 0;
+  [linear] <c8>:  -<x_6>[C] +<x_8>[C] <= 0;
+  [linear] <c9>:  -<x_7>[C] +<x_8>[C] <= 0;
+  [linear] <c10>:  -<x_4>[C] <= -1;
+  [linear] <c11>:  -<x_5>[C] <= -1;
+  [linear] <c12>:  -<x_6>[C] <= -1;
+  [linear] <c13>:  -<x_7>[C] <= -1;
+  [linear] <c14>: <x_4>[C] <= 2;
+  [linear] <c15>: <x_5>[C] <= 2;
+  [linear] <c16>: <x_6>[C] <= 2;
+  [linear] <c17>: <x_7>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 X_0_0 +1 X_0_1 +1 X_1_0 +1 X_1_1
-Subject to
- maximum_1_0_0_0: +1 maximum_1_0_0 -1 X_0_0 >= +0
- maximum_1_0_0_1: +1 maximum_1_0_1 -1 X_0_1 >= +0
- maximum_1_0_1_0: +1 maximum_1_1_0 -1 X_1_0 >= +0
- maximum_1_0_1_1: +1 maximum_1_1_1 -1 X_1_1 >= +0
- maximum_1_1_0_0: +1 maximum_1_0_0 -1 z >= +0
- maximum_1_1_0_1: +1 maximum_1_0_1 -1 z >= +0
- maximum_1_1_1_0: +1 maximum_1_1_0 -1 z >= +0
- maximum_1_1_1_1: +1 maximum_1_1_1 -1 z >= +0
- maximum_1_2_0_0: +1 maximum_1_0_0 >= +1
- maximum_1_2_0_1: +1 maximum_1_0_1 >= +1
- maximum_1_2_1_0: +1 maximum_1_1_0 >= +1
- maximum_1_2_1_1: +1 maximum_1_1_1 >= +1
- 67_0_0: +1 maximum_1_0_0 <= +2
- 67_0_1: +1 maximum_1_0_1 <= +2
- 67_1_0: +1 maximum_1_1_0 <= +2
- 67_1_1: +1 maximum_1_1_1 <= +2
- 71: +1 z = +1
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- z free
- maximum_1_0_0 free
- maximum_1_0_1 free
- maximum_1_1_0 free
- maximum_1_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <z>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <maximum_1_1_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <maximum_1_0_0_0>: <maximum_1_0_0>[C] -<X_0_0>[C] >= 0;
+  [linear] <maximum_1_0_0_1>: <maximum_1_0_1>[C] -<X_0_1>[C] >= 0;
+  [linear] <maximum_1_0_1_0>: <maximum_1_1_0>[C] -<X_1_0>[C] >= 0;
+  [linear] <maximum_1_0_1_1>: <maximum_1_1_1>[C] -<X_1_1>[C] >= 0;
+  [linear] <maximum_1_1_0_0>: <maximum_1_0_0>[C] -<z>[C] >= 0;
+  [linear] <maximum_1_1_0_1>: <maximum_1_0_1>[C] -<z>[C] >= 0;
+  [linear] <maximum_1_1_1_0>: <maximum_1_1_0>[C] -<z>[C] >= 0;
+  [linear] <maximum_1_1_1_1>: <maximum_1_1_1>[C] -<z>[C] >= 0;
+  [linear] <maximum_1_2_0_0>: <maximum_1_0_0>[C] >= 1;
+  [linear] <maximum_1_2_0_1>: <maximum_1_0_1>[C] >= 1;
+  [linear] <maximum_1_2_1_0>: <maximum_1_1_0>[C] >= 1;
+  [linear] <maximum_1_2_1_1>: <maximum_1_1_1>[C] >= 1;
+  [linear] <67_0_0>: <maximum_1_0_0>[C] <= 2;
+  [linear] <67_0_1>: <maximum_1_0_1>[C] <= 2;
+  [linear] <67_1_0>: <maximum_1_1_0>[C] <= 2;
+  [linear] <67_1_1>: <maximum_1_1_1>[C] <= 2;
+  [linear] <71>: <z>[C] == 1;
+END

--- a/tests/snapshots/scip/genexpr_norm1_00.txt
+++ b/tests/snapshots/scip/genexpr_norm1_00.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>))+<x2>*(-1) <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_01.txt
+++ b/tests/snapshots/scip/genexpr_norm1_01.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +1
- c2: -1 x_0 -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 1;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>+(-1)))+<x2>*(-1) <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>+(-1)))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_02.txt
+++ b/tests/snapshots/scip/genexpr_norm1_02.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>))+<x2>*(-1)+1 <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>))+<x2>*(-1)+1 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_03.txt
+++ b/tests/snapshots/scip/genexpr_norm1_03.txt
@@ -8,22 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 -1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
- c3: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c3>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
-\   [nonlinear] <12>: abs((<x>)) <= 1;
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <12>: abs((<x>)) <= 1;
+END

--- a/tests/snapshots/scip/genexpr_norm1_04.txt
+++ b/tests/snapshots/scip/genexpr_norm1_04.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x_0>))+<x2>*(-1) <= 0;
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x_0>))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_05.txt
+++ b/tests/snapshots/scip/genexpr_norm1_05.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +1
- c2: -1 x_0 -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 1;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x_0>+(-1)))+<x2>*(-1) <= 0;
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x_0>+(-1)))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_06.txt
+++ b/tests/snapshots/scip/genexpr_norm1_06.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x_0>))+<x2>*(-1)+1 <= 0;
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x_0>))+<x2>*(-1)+1 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_07.txt
+++ b/tests/snapshots/scip/genexpr_norm1_07.txt
@@ -8,22 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 -1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
- c3: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c3>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
-\   [nonlinear] <12>: abs((<x_0>)) <= 1;
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <12>: abs((<x_0>)) <= 1;
+END

--- a/tests/snapshots/scip/genexpr_norm1_08.txt
+++ b/tests/snapshots/scip/genexpr_norm1_08.txt
@@ -7,27 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 +1 x_2 <= +0
- c2: -1 x_1 +1 x_3 <= +0
- c3: -1 x_0 -1 x_2 <= +0
- c4: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<x_0>))+abs((<x_1>))+<x3>*(-1) <= 0;
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x_0>))+abs((<x_1>))+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_09.txt
+++ b/tests/snapshots/scip/genexpr_norm1_09.txt
@@ -7,27 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 +1 x_2 <= +1.00005
- c2: -1 x_1 +1 x_3 <= -0.99995
- c3: -1 x_0 -1 x_2 <= -1.00005
- c4: -1 x_1 -1 x_3 <= +0.99995
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_2>[C] <= 1.00005;
+  [linear] <c2>:  -<x_1>[C] +<x_3>[C] <= -0.99995;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= -1.00005;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 0.99995;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<x_0>+(-1.00005)))+abs((<x_1>+0.99995))+<x3>*(-1) <= 0;
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x_0>+(-1.00005)))+abs((<x_1>+0.99995))+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_10.txt
+++ b/tests/snapshots/scip/genexpr_norm1_10.txt
@@ -7,27 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 +1 x_2 <= +0
- c2: -1 x_1 +1 x_3 <= +0
- c3: -1 x_0 -1 x_2 <= +0
- c4: -1 x_1 -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] +<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: abs((<x_0>))+abs((<x_1>))+<x3>*(-1)+2 <= 0;
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x_0>))+abs((<x_1>))+<x3>*(-1)+2 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_11.txt
+++ b/tests/snapshots/scip/genexpr_norm1_11.txt
@@ -8,27 +8,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1.00005 x_0 +0.99995 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_3 <= +0
- c3: -1 x_0 -1 x_2 <= +0
- c4: -1 x_1 -1 x_3 <= +0
- c5: +1 x_2 +1 x_3 <= +1.4142135623731
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1.00005, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0.99995, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 0;
+  [linear] <c5>: <x_2>[C] +<x_3>[C] <= 1.4142135623731;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1.00005 x_0 -0.99995 x_1
-Subject to
-\   [nonlinear] <14>: abs((<x_0>))+abs((<x_1>)) <= 1.4142135623731;
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1.00005, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-0.99995, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <14>: abs((<x_0>))+abs((<x_1>)) <= 1.4142135623731;
+END

--- a/tests/snapshots/scip/genexpr_norm1_12.txt
+++ b/tests/snapshots/scip/genexpr_norm1_12.txt
@@ -7,37 +7,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 +1 x_4 <= +0
- c2: -1 x_1 +1 x_5 <= +0
- c3: -1 x_2 +1 x_6 <= +0
- c4: -1 x_3 +1 x_7 <= +0
- c5: -1 x_0 -1 x_4 <= +0
- c6: -1 x_1 -1 x_5 <= +0
- c7: -1 x_2 -1 x_6 <= +0
- c8: -1 x_3 -1 x_7 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] +<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] +<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] +<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] -<x_7>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1) <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_13.txt
+++ b/tests/snapshots/scip/genexpr_norm1_13.txt
@@ -8,37 +8,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 +1 x_4 <= +2
- c2: -1 x_1 +1 x_5 <= -2
- c3: -1 x_2 +1 x_6 <= +1
- c4: -1 x_3 +1 x_7 <= -4
- c5: -1 x_0 -1 x_4 <= -2
- c6: -1 x_1 -1 x_5 <= +2
- c7: -1 x_2 -1 x_6 <= -1
- c8: -1 x_3 -1 x_7 <= +4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_4>[C] <= 2;
+  [linear] <c2>:  -<x_1>[C] +<x_5>[C] <= -2;
+  [linear] <c3>:  -<x_2>[C] +<x_6>[C] <= 1;
+  [linear] <c4>:  -<x_3>[C] +<x_7>[C] <= -4;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] <= -2;
+  [linear] <c6>:  -<x_1>[C] -<x_5>[C] <= 2;
+  [linear] <c7>:  -<x_2>[C] -<x_6>[C] <= -1;
+  [linear] <c8>:  -<x_3>[C] -<x_7>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>+(-2)))+abs((<X_0_1>+(-1)))+abs((<X_1_0>+2))+abs((<X_1_1>+4))+<x5>*(-1) <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>+(-2)))+abs((<X_0_1>+(-1)))+abs((<X_1_0>+2))+abs((<X_1_1>+4))+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_14.txt
+++ b/tests/snapshots/scip/genexpr_norm1_14.txt
@@ -8,37 +8,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 +1 x_4 <= +0
- c2: -1 x_1 +1 x_5 <= +0
- c3: -1 x_2 +1 x_6 <= +0
- c4: -1 x_3 +1 x_7 <= +0
- c5: -1 x_0 -1 x_4 <= +0
- c6: -1 x_1 -1 x_5 <= +0
- c7: -1 x_2 -1 x_6 <= +0
- c8: -1 x_3 -1 x_7 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] +<x_5>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] +<x_6>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] +<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] -<x_7>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1)+9 <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>))+<x5>*(-1)+9 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm1_15.txt
+++ b/tests/snapshots/scip/genexpr_norm1_15.txt
@@ -9,37 +9,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -2 x_0 +2 x_1 -1 x_2 +4 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_5 <= +0
- c3: +1 x_2 -1 x_6 <= +0
- c4: +1 x_3 -1 x_7 <= +0
- c5: -1 x_0 -1 x_4 <= +0
- c6: -1 x_1 -1 x_5 <= +0
- c7: -1 x_2 -1 x_6 <= +0
- c8: -1 x_3 -1 x_7 <= +0
- c9: +1 x_4 +1 x_5 +1 x_6 +1 x_7 <= +6
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=4, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_5>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] -<x_6>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] -<x_7>[C] <= 0;
+  [linear] <c9>: <x_4>[C] +<x_5>[C] +<x_6>[C] +<x_7>[C] <= 6;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +2 X_0_0 +1 X_0_1 -2 X_1_0 -4 X_1_1
-Subject to
-\   [nonlinear] <14>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>)) <= 6;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=-2, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=-4, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <14>: abs((<X_0_0>))+abs((<X_0_1>))+abs((<X_1_0>))+abs((<X_1_1>)) <= 6;
+END

--- a/tests/snapshots/scip/genexpr_norm2_00.txt
+++ b/tests/snapshots/scip/genexpr_norm2_00.txt
@@ -7,24 +7,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: + [ +1 soc_t_1 * soc_t_1 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [nonlinear] <c3>: <soc_t_1>*<soc_t_1>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: ((<x>*<x>))^0.5+<x2>*(-1) <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x>*<x>))^0.5+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_01.txt
+++ b/tests/snapshots/scip/genexpr_norm2_01.txt
@@ -7,24 +7,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = -1
- c3: + [ +1 soc_t_1 * soc_t_1 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == -1;
+  [nonlinear] <c3>: <soc_t_1>*<soc_t_1>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: ((<x>*<x>+<x>*(-2)+1))^0.5+<x2>*(-1) <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x>*<x>+<x>*(-2)+1))^0.5+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_02.txt
+++ b/tests/snapshots/scip/genexpr_norm2_02.txt
@@ -7,24 +7,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: + [ +1 soc_t_1 * soc_t_1 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [nonlinear] <c3>: <soc_t_1>*<soc_t_1>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: ((<x>*<x>))^0.5+<x2>*(-1)+1 <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x>*<x>))^0.5+<x2>*(-1)+1 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_03.txt
+++ b/tests/snapshots/scip/genexpr_norm2_03.txt
@@ -8,24 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_1 <= +1
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: +1 soc_t_2 -1 x_0 = +0
- c4: + [ +1 soc_t_2 * soc_t_2 -1 soc_t_1 * soc_t_1 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] <= 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_0>[C] == 0;
+  [nonlinear] <c4>: <soc_t_2>*<soc_t_2>-<soc_t_1>*<soc_t_1> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
-\   [nonlinear] <12>: ((<x>*<x>))^0.5 <= 1;
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <12>: ((<x>*<x>))^0.5 <= 1;
+END

--- a/tests/snapshots/scip/genexpr_norm2_04.txt
+++ b/tests/snapshots/scip/genexpr_norm2_04.txt
@@ -7,24 +7,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: + [ +1 soc_t_1 * soc_t_1 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [nonlinear] <c3>: <soc_t_1>*<soc_t_1>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: ((<x_0>*<x_0>))^0.5+<x2>*(-1) <= 0;
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x_0>*<x_0>))^0.5+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_05.txt
+++ b/tests/snapshots/scip/genexpr_norm2_05.txt
@@ -7,24 +7,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = -1
- c3: + [ +1 soc_t_1 * soc_t_1 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == -1;
+  [nonlinear] <c3>: <soc_t_1>*<soc_t_1>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: ((<x_0>*<x_0>+<x_0>*(-2)+1))^0.5+<x2>*(-1) <= 0;
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x_0>*<x_0>+<x_0>*(-2)+1))^0.5+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_06.txt
+++ b/tests/snapshots/scip/genexpr_norm2_06.txt
@@ -7,24 +7,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: + [ +1 soc_t_1 * soc_t_1 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [nonlinear] <c3>: <soc_t_1>*<soc_t_1>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: ((<x_0>*<x_0>))^0.5+<x2>*(-1)+1 <= 0;
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x_0>*<x_0>))^0.5+<x2>*(-1)+1 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_07.txt
+++ b/tests/snapshots/scip/genexpr_norm2_07.txt
@@ -8,24 +8,25 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_1 <= +1
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: +1 soc_t_2 -1 x_0 = +0
- c4: + [ +1 soc_t_2 * soc_t_2 -1 soc_t_1 * soc_t_1 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] <= 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_0>[C] == 0;
+  [nonlinear] <c4>: <soc_t_2>*<soc_t_2>-<soc_t_1>*<soc_t_1> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
-\   [nonlinear] <12>: ((<x_0>*<x_0>))^0.5 <= 1;
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <12>: ((<x_0>*<x_0>))^0.5 <= 1;
+END

--- a/tests/snapshots/scip/genexpr_norm2_08.txt
+++ b/tests/snapshots/scip/genexpr_norm2_08.txt
@@ -7,28 +7,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: +1 soc_t_2 -1 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: ((<x_0>*<x_0>+<x_1>*<x_1>))^0.5+<x3>*(-1) <= 0;
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x_0>*<x_0>+<x_1>*<x_1>))^0.5+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_09.txt
+++ b/tests/snapshots/scip/genexpr_norm2_09.txt
@@ -7,28 +7,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = -1.00005
- c3: +1 soc_t_2 -1 x_2 = +0.99995
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == -1.00005;
+  [linear] <c3>: <soc_t_2>[C] -<x_2>[C] == 0.99995;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: ((<x_0>*<x_0>+<x_0>*(-2.0001)+<x_1>*<x_1>+<x_1>*1.9999+2.000000005))^0.5+<x3>*(-1) <= 0;
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x_0>*<x_0>+<x_0>*(-2.0001)+<x_1>*<x_1>+<x_1>*1.9999+2.000000005))^0.5+<x3>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_10.txt
+++ b/tests/snapshots/scip/genexpr_norm2_10.txt
@@ -7,28 +7,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: +1 soc_t_2 -1 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: ((<x_0>*<x_0>+<x_1>*<x_1>))^0.5+<x3>*(-1)+1.41421356414086 <= 0;
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<x_0>*<x_0>+<x_1>*<x_1>))^0.5+<x3>*(-1)+1.41421356414086 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_11.txt
+++ b/tests/snapshots/scip/genexpr_norm2_11.txt
@@ -8,28 +8,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1.00005 x_0 +0.99995 x_1
-Subject to
- c1: +1 x_2 <= +1.4142135623731
- c2: +1 soc_t_1 -1 x_2 = +0
- c3: +1 soc_t_2 -1 x_0 = +0
- c4: +1 soc_t_3 -1 x_1 = +0
- c5: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_1 * soc_t_1 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1.00005, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0.99995, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_2>[C] <= 1.4142135623731;
+  [linear] <c2>: <soc_t_1>[C] -<x_2>[C] == 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_0>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -<x_1>[C] == 0;
+  [nonlinear] <c5>: <soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_1>*<soc_t_1> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1.00005 x_0 -0.99995 x_1
-Subject to
-\   [nonlinear] <14>: ((<x_0>*<x_0>+<x_1>*<x_1>))^0.5 <= 1.4142135623731;
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1.00005, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-0.99995, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <14>: ((<x_0>*<x_0>+<x_1>*<x_1>))^0.5 <= 1.4142135623731;
+END

--- a/tests/snapshots/scip/genexpr_norm2_12.txt
+++ b/tests/snapshots/scip/genexpr_norm2_12.txt
@@ -7,37 +7,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: +1 soc_t_2 -1 x_2 = +0
- c4: +1 soc_t_3 -1 x_3 = +0
- c5: +1 soc_t_4 -1 x_4 = +0
- c6: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_0 * soc_t_0
- ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
- soc_t_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_2>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -<x_3>[C] == 0;
+  [linear] <c5>: <soc_t_4>[C] -<x_4>[C] == 0;
+  [nonlinear] <c6>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>+<soc_t_4>*<soc_t_4>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: ((<X_0_0>*<X_0_0>+<X_0_1>*<X_0_1>+<X_1_0>*<X_1_0>+<X_1_1>*<X_1_1>))^0.5+<x5>*(-1) <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<X_0_0>*<X_0_0>+<X_0_1>*<X_0_1>+<X_1_0>*<X_1_0>+<X_1_1>*<X_1_1>))^0.5+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_13.txt
+++ b/tests/snapshots/scip/genexpr_norm2_13.txt
@@ -8,37 +8,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = -2
- c3: +1 soc_t_2 -1 x_2 = +2
- c4: +1 soc_t_3 -1 x_3 = -1
- c5: +1 soc_t_4 -1 x_4 = +4
- c6: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_0 * soc_t_0
- ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
- soc_t_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == -2;
+  [linear] <c3>: <soc_t_2>[C] -<x_2>[C] == 2;
+  [linear] <c4>: <soc_t_3>[C] -<x_3>[C] == -1;
+  [linear] <c5>: <soc_t_4>[C] -<x_4>[C] == 4;
+  [nonlinear] <c6>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>+<soc_t_4>*<soc_t_4>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: ((<X_0_0>*<X_0_0>+<X_0_0>*(-4)+<X_0_1>*<X_0_1>+<X_0_1>*(-2)+<X_1_0>*<X_1_0>+<X_1_0>*4+<X_1_1>*<X_1_1>+<X_1_1>*8+25))^0.5+<x5>*(-1) <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<X_0_0>*<X_0_0>+<X_0_0>*(-4)+<X_0_1>*<X_0_1>+<X_0_1>*(-2)+<X_1_0>*<X_1_0>+<X_1_0>*4+<X_1_1>*<X_1_1>+<X_1_1>*8+25))^0.5+<x5>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_14.txt
+++ b/tests/snapshots/scip/genexpr_norm2_14.txt
@@ -8,37 +8,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +0
- c2: +1 soc_t_1 -1 x_1 = +0
- c3: +1 soc_t_2 -1 x_2 = +0
- c4: +1 soc_t_3 -1 x_3 = +0
- c5: +1 soc_t_4 -1 x_4 = +0
- c6: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_0 * soc_t_0
- ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
- soc_t_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_1>[C] == 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_2>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -<x_3>[C] == 0;
+  [linear] <c5>: <soc_t_4>[C] -<x_4>[C] == 0;
+  [nonlinear] <c6>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>+<soc_t_4>*<soc_t_4>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x5
-Subject to
-\   [nonlinear] <c1>: ((<X_0_0>*<X_0_0>+<X_0_1>*<X_0_1>+<X_1_0>*<X_1_0>+<X_1_1>*<X_1_1>))^0.5+<x5>*(-1)+5 <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
- x5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: ((<X_0_0>*<X_0_0>+<X_0_1>*<X_0_1>+<X_1_0>*<X_1_0>+<X_1_1>*<X_1_1>))^0.5+<x5>*(-1)+5 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norm2_15.txt
+++ b/tests/snapshots/scip/genexpr_norm2_15.txt
@@ -12,13 +12,13 @@ AFTER COMPILATION
 Solver 'SCIP' failed. Try another solver, or solve with verbose=True for more information.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +2 X_0_0 +1 X_0_1 -2 X_1_0 -4 X_1_1
-Subject to
-\   [nonlinear] <14>: ((<X_0_0>*<X_0_0>+<X_0_1>*<X_0_1>+<X_1_0>*<X_1_0>+<X_1_1>*<X_1_1>))^0.5 <= 6;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=-2, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=-4, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <14>: ((<X_0_0>*<X_0_0>+<X_0_1>*<X_0_1>+<X_1_0>*<X_1_0>+<X_1_1>*<X_1_1>))^0.5 <= 6;
+END

--- a/tests/snapshots/scip/genexpr_norminf_00.txt
+++ b/tests/snapshots/scip/genexpr_norminf_00.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>))+<x2>*(-1) <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_01.txt
+++ b/tests/snapshots/scip/genexpr_norminf_01.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +1
- c2: -1 x_0 -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 1;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>+(-1)))+<x2>*(-1) <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>+(-1)))+<x2>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_02.txt
+++ b/tests/snapshots/scip/genexpr_norminf_02.txt
@@ -7,22 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: abs((<x>))+<x2>*(-1)+1 <= 0;
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: abs((<x>))+<x2>*(-1)+1 <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_03.txt
+++ b/tests/snapshots/scip/genexpr_norminf_03.txt
@@ -8,22 +8,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 -1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
- c3: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c3>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
-\   [nonlinear] <12>: abs((<x>)) <= 1;
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <12>: abs((<x>)) <= 1;
+END

--- a/tests/snapshots/scip/genexpr_norminf_04.txt
+++ b/tests/snapshots/scip/genexpr_norminf_04.txt
@@ -7,21 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_05.txt
+++ b/tests/snapshots/scip/genexpr_norminf_05.txt
@@ -7,21 +7,22 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +1
- c2: -1 x_0 -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 1;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>+(-1)))+<norminf_1>*(-1) <= 0;
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>+(-1)))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_06.txt
+++ b/tests/snapshots/scip/genexpr_norminf_06.txt
@@ -7,21 +7,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1 +1
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_07.txt
+++ b/tests/snapshots/scip/genexpr_norminf_07.txt
@@ -8,23 +8,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 -1 x_1 <= +0
- c2: -1 x_0 -1 x_1 <= +0
- c3: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c3>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
- 12: +1 norminf_1 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=0, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
+  [linear] <12>: <norminf_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/genexpr_norminf_08.txt
+++ b/tests/snapshots/scip/genexpr_norminf_08.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 +1 x_2 <= +0
- c3: -1 x_0 -1 x_1 <= +0
- c4: -1 x_0 -1 x_2 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c4>:  -<x_0>[C] -<x_2>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1>: abs((<x_1>))+<norminf_1>*(-1) <= 0;
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1>: abs((<x_1>))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_09.txt
+++ b/tests/snapshots/scip/genexpr_norminf_09.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +1.00005
- c2: -1 x_0 +1 x_2 <= -0.99995
- c3: -1 x_0 -1 x_1 <= -1.00005
- c4: -1 x_0 -1 x_2 <= +0.99995
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 1.00005;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= -0.99995;
+  [linear] <c3>:  -<x_0>[C] -<x_1>[C] <= -1.00005;
+  [linear] <c4>:  -<x_0>[C] -<x_2>[C] <= 0.99995;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>+(-1.00005)))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1>: abs((<x_1>+0.99995))+<norminf_1>*(-1) <= 0;
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>+(-1.00005)))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1>: abs((<x_1>+0.99995))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_10.txt
+++ b/tests/snapshots/scip/genexpr_norminf_10.txt
@@ -7,26 +7,28 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 +1 x_2 <= +0
- c3: -1 x_0 -1 x_1 <= +0
- c4: -1 x_0 -1 x_2 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c4>:  -<x_0>[C] -<x_2>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1 +1.00005
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1>: abs((<x_1>))+<norminf_1>*(-1) <= 0;
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1.00005
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1>: abs((<x_1>))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_11.txt
+++ b/tests/snapshots/scip/genexpr_norminf_11.txt
@@ -8,28 +8,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1.00005 x_0 +0.99995 x_1
-Subject to
- c1: +1 x_0 -1 x_2 <= +0
- c2: +1 x_1 -1 x_2 <= +0
- c3: -1 x_0 -1 x_2 <= +0
- c4: -1 x_1 -1 x_2 <= +0
- c5: +1 x_2 <= +1.4142135623731
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1.00005, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0.99995, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_1>[C] -<x_2>[C] <= 0;
+  [linear] <c5>: <x_2>[C] <= 1.4142135623731;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1.00005 x_0 -0.99995 x_1
-Subject to
-\   [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1>: abs((<x_1>))+<norminf_1>*(-1) <= 0;
- 14: +1 norminf_1 <= +1.4142135623731
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1.00005, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-0.99995, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=0, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0>: abs((<x_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1>: abs((<x_1>))+<norminf_1>*(-1) <= 0;
+  [linear] <14>: <norminf_1>[C] <= 1.4142135623731;
+END

--- a/tests/snapshots/scip/genexpr_norminf_12.txt
+++ b/tests/snapshots/scip/genexpr_norminf_12.txt
@@ -7,36 +7,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 +1 x_2 <= +0
- c3: -1 x_0 +1 x_3 <= +0
- c4: -1 x_0 +1 x_4 <= +0
- c5: -1 x_0 -1 x_1 <= +0
- c6: -1 x_0 -1 x_2 <= +0
- c7: -1 x_0 -1 x_3 <= +0
- c8: -1 x_0 -1 x_4 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] +<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c6>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c7>:  -<x_0>[C] -<x_3>[C] <= 0;
+  [linear] <c8>:  -<x_0>[C] -<x_4>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1
-Subject to
-\   [nonlinear] <norminf_1_0_0>: abs((<X_0_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_0_1>: abs((<X_0_1>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_0>: abs((<X_1_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_1>: abs((<X_1_1>))+<norminf_1>*(-1) <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0_0>: abs((<X_0_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_0_1>: abs((<X_0_1>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_0>: abs((<X_1_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_1>: abs((<X_1_1>))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_13.txt
+++ b/tests/snapshots/scip/genexpr_norminf_13.txt
@@ -8,36 +8,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +2
- c2: -1 x_0 +1 x_2 <= -2
- c3: -1 x_0 +1 x_3 <= +1
- c4: -1 x_0 +1 x_4 <= -4
- c5: -1 x_0 -1 x_1 <= -2
- c6: -1 x_0 -1 x_2 <= +2
- c7: -1 x_0 -1 x_3 <= -1
- c8: -1 x_0 -1 x_4 <= +4
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 2;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= -2;
+  [linear] <c3>:  -<x_0>[C] +<x_3>[C] <= 1;
+  [linear] <c4>:  -<x_0>[C] +<x_4>[C] <= -4;
+  [linear] <c5>:  -<x_0>[C] -<x_1>[C] <= -2;
+  [linear] <c6>:  -<x_0>[C] -<x_2>[C] <= 2;
+  [linear] <c7>:  -<x_0>[C] -<x_3>[C] <= -1;
+  [linear] <c8>:  -<x_0>[C] -<x_4>[C] <= 4;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1
-Subject to
-\   [nonlinear] <norminf_1_0_0>: abs((<X_0_0>+(-2)))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_0_1>: abs((<X_0_1>+(-1)))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_0>: abs((<X_1_0>+2))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_1>: abs((<X_1_1>+4))+<norminf_1>*(-1) <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0_0>: abs((<X_0_0>+(-2)))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_0_1>: abs((<X_0_1>+(-1)))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_0>: abs((<X_1_0>+2))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_1>: abs((<X_1_1>+4))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_14.txt
+++ b/tests/snapshots/scip/genexpr_norminf_14.txt
@@ -8,36 +8,38 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 +1 x_1 <= +0
- c2: -1 x_0 +1 x_2 <= +0
- c3: -1 x_0 +1 x_3 <= +0
- c4: -1 x_0 +1 x_4 <= +0
- c5: -1 x_0 -1 x_1 <= +0
- c6: -1 x_0 -1 x_2 <= +0
- c7: -1 x_0 -1 x_3 <= +0
- c8: -1 x_0 -1 x_4 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] +<x_1>[C] <= 0;
+  [linear] <c2>:  -<x_0>[C] +<x_2>[C] <= 0;
+  [linear] <c3>:  -<x_0>[C] +<x_3>[C] <= 0;
+  [linear] <c4>:  -<x_0>[C] +<x_4>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_1>[C] <= 0;
+  [linear] <c6>:  -<x_0>[C] -<x_2>[C] <= 0;
+  [linear] <c7>:  -<x_0>[C] -<x_3>[C] <= 0;
+  [linear] <c8>:  -<x_0>[C] -<x_4>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 norminf_1 +4
-Subject to
-\   [nonlinear] <norminf_1_0_0>: abs((<X_0_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_0_1>: abs((<X_0_1>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_0>: abs((<X_1_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_1>: abs((<X_1_1>))+<norminf_1>*(-1) <= 0;
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +4
+VARIABLES
+  [continuous] <X_0_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0_0>: abs((<X_0_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_0_1>: abs((<X_0_1>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_0>: abs((<X_1_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_1>: abs((<X_1_1>))+<norminf_1>*(-1) <= 0;
+END

--- a/tests/snapshots/scip/genexpr_norminf_15.txt
+++ b/tests/snapshots/scip/genexpr_norminf_15.txt
@@ -9,38 +9,39 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -2 x_0 +2 x_1 -1 x_2 +4 x_3
-Subject to
- c1: +1 x_0 -1 x_4 <= +0
- c2: +1 x_1 -1 x_4 <= +0
- c3: +1 x_2 -1 x_4 <= +0
- c4: +1 x_3 -1 x_4 <= +0
- c5: -1 x_0 -1 x_4 <= +0
- c6: -1 x_1 -1 x_4 <= +0
- c7: -1 x_2 -1 x_4 <= +0
- c8: -1 x_3 -1 x_4 <= +0
- c9: +1 x_4 <= +6
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=4, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c2>: <x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c3>: <x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c4>: <x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_4>[C] <= 0;
+  [linear] <c6>:  -<x_1>[C] -<x_4>[C] <= 0;
+  [linear] <c7>:  -<x_2>[C] -<x_4>[C] <= 0;
+  [linear] <c8>:  -<x_3>[C] -<x_4>[C] <= 0;
+  [linear] <c9>: <x_4>[C] <= 6;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +2 X_0_0 +1 X_0_1 -2 X_1_0 -4 X_1_1
-Subject to
-\   [nonlinear] <norminf_1_0_0>: abs((<X_0_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_0_1>: abs((<X_0_1>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_0>: abs((<X_1_0>))+<norminf_1>*(-1) <= 0;
-\   [nonlinear] <norminf_1_1_1>: abs((<X_1_1>))+<norminf_1>*(-1) <= 0;
- 14: +1 norminf_1 <= +6
-Bounds
- X_0_0 free
- X_0_1 free
- X_1_0 free
- X_1_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <X_0_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <X_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <X_1_0>: obj=-2, original bounds=[-inf,+inf]
+  [continuous] <X_1_1>: obj=-4, original bounds=[-inf,+inf]
+  [continuous] <norminf_1>: obj=0, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <norminf_1_0_0>: abs((<X_0_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_0_1>: abs((<X_0_1>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_0>: abs((<X_1_0>))+<norminf_1>*(-1) <= 0;
+  [nonlinear] <norminf_1_1_1>: abs((<X_1_1>))+<norminf_1>*(-1) <= 0;
+  [linear] <14>: <norminf_1>[C] <= 6;
+END

--- a/tests/snapshots/scip/hstack_00.txt
+++ b/tests/snapshots/scip/hstack_00.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 8: +1 x >= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <8>: <x>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_01.txt
+++ b/tests/snapshots/scip/hstack_01.txt
@@ -10,23 +10,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1 y +1
-Subject to
- 17: +1 x >= +1
- 21: +1 y >= +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <17>: <x>[C] >= 1;
+  [linear] <21>: <y>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_02.txt
+++ b/tests/snapshots/scip/hstack_02.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x
-Subject to
- 29: +1 x >= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <29>: <x>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_03.txt
+++ b/tests/snapshots/scip/hstack_03.txt
@@ -10,23 +10,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +3 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x +3 y +1
-Subject to
- 40: +1 x >= +1
- 44: +1 y >= +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <40>: <x>[C] >= 1;
+  [linear] <44>: <y>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_04.txt
+++ b/tests/snapshots/scip/hstack_04.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
- 7_0: +1 x_0 >= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <7_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_05.txt
+++ b/tests/snapshots/scip/hstack_05.txt
@@ -10,23 +10,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 y_0 +1
-Subject to
- 14_0: +1 x_0 >= +1
- 18_0: +1 y_0 >= +1
-Bounds
- x_0 free
- y_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <14_0>: <x_0>[C] >= 1;
+  [linear] <18_0>: <y_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_06.txt
+++ b/tests/snapshots/scip/hstack_06.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0
-Subject to
- 25_0: +1 x_0 >= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <25_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_07.txt
+++ b/tests/snapshots/scip/hstack_07.txt
@@ -10,23 +10,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +3 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0 +3 y_0 +1
-Subject to
- 34_0: +1 x_0 >= +1
- 38_0: +1 y_0 >= +1
-Bounds
- x_0 free
- y_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <34_0>: <x_0>[C] >= 1;
+  [linear] <38_0>: <y_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_08.txt
+++ b/tests/snapshots/scip/hstack_08.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 7_0: +1 x_0 >= +1
- 7_1: +1 x_1 >= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <7_0>: <x_0>[C] >= 1;
+  [linear] <7_1>: <x_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_09.txt
+++ b/tests/snapshots/scip/hstack_09.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +2 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0 +2 x_1
-Subject to
- 16_0: +1 x_0 >= +1
- 16_1: +1 x_1 >= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <16_0>: <x_0>[C] >= 1;
+  [linear] <16_1>: <x_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_10.txt
+++ b/tests/snapshots/scip/hstack_10.txt
@@ -10,27 +10,28 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1 +1 y_0 +1
-Subject to
- 24_0: +1 x_0 >= +1
- 24_1: +1 x_1 >= +1
- 28_0: +1 y_0 >= +1
-Bounds
- x_0 free
- x_1 free
- y_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <24_0>: <x_0>[C] >= 1;
+  [linear] <24_1>: <x_1>[C] >= 1;
+  [linear] <28_0>: <y_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_11.txt
+++ b/tests/snapshots/scip/hstack_11.txt
@@ -10,27 +10,28 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +2 x_1 +3 x_2
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0 +2 x_1 +3 y_0 +1
-Subject to
- 39_0: +1 x_0 >= +1
- 39_1: +1 x_1 >= +1
- 43_0: +1 y_0 >= +1
-Bounds
- x_0 free
- x_1 free
- y_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <39_0>: <x_0>[C] >= 1;
+  [linear] <39_1>: <x_1>[C] >= 1;
+  [linear] <43_0>: <y_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_12.txt
+++ b/tests/snapshots/scip/hstack_12.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1
-Subject to
- 8_0_0: +1 x_0_0 >= +1
- 8_0_1: +1 x_0_1 >= +1
- 8_1_0: +1 x_1_0 >= +1
- 8_1_1: +1 x_1_1 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <8_0_0>: <x_0_0>[C] >= 1;
+  [linear] <8_0_1>: <x_0_1>[C] >= 1;
+  [linear] <8_1_0>: <x_1_0>[C] >= 1;
+  [linear] <8_1_1>: <x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_13.txt
+++ b/tests/snapshots/scip/hstack_13.txt
@@ -11,39 +11,40 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
- c5: -1 x_4 <= -1
- c6: -1 x_5 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+  [linear] <c5>:  -<x_4>[C] <= -1;
+  [linear] <c6>:  -<x_5>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1 +1 y_0_0 +1 y_1_0 +6
-Subject to
- 15_0_0: +1 x_0_0 >= +1
- 15_0_1: +1 x_0_1 >= +1
- 15_1_0: +1 x_1_0 >= +1
- 15_1_1: +1 x_1_1 >= +1
- 20_0_0: +1 y_0_0 >= +1
- 20_1_0: +1 y_1_0 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
- y_0_0 free
- y_1_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +6
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_1_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <15_0_0>: <x_0_0>[C] >= 1;
+  [linear] <15_0_1>: <x_0_1>[C] >= 1;
+  [linear] <15_1_0>: <x_1_0>[C] >= 1;
+  [linear] <15_1_1>: <x_1_1>[C] >= 1;
+  [linear] <20_0_0>: <y_0_0>[C] >= 1;
+  [linear] <20_1_0>: <y_1_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_14.txt
+++ b/tests/snapshots/scip/hstack_14.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1
-Subject to
- 29_0_0: +1 x_0_0 >= +1
- 29_0_1: +1 x_0_1 >= +1
- 29_1_0: +1 x_1_0 >= +1
- 29_1_1: +1 x_1_1 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <29_0_0>: <x_0_0>[C] >= 1;
+  [linear] <29_0_1>: <x_0_1>[C] >= 1;
+  [linear] <29_1_0>: <x_1_0>[C] >= 1;
+  [linear] <29_1_1>: <x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/hstack_15.txt
+++ b/tests/snapshots/scip/hstack_15.txt
@@ -11,39 +11,40 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3 +3 x_4 +3 x_5
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
- c5: -1 x_4 <= -1
- c6: -1 x_5 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=3, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+  [linear] <c5>:  -<x_4>[C] <= -1;
+  [linear] <c6>:  -<x_5>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1 +3 y_0_0 +3 y_1_0 +6
-Subject to
- 40_0_0: +1 x_0_0 >= +1
- 40_0_1: +1 x_0_1 >= +1
- 40_1_0: +1 x_1_0 >= +1
- 40_1_1: +1 x_1_1 >= +1
- 45_0_0: +1 y_0_0 >= +1
- 45_1_0: +1 y_1_0 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
- y_0_0 free
- y_1_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +6
+VARIABLES
+  [continuous] <x_0_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <y_0_0>: obj=3, original bounds=[-inf,+inf]
+  [continuous] <y_1_0>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <40_0_0>: <x_0_0>[C] >= 1;
+  [linear] <40_0_1>: <x_0_1>[C] >= 1;
+  [linear] <40_1_0>: <x_1_0>[C] >= 1;
+  [linear] <40_1_1>: <x_1_1>[C] >= 1;
+  [linear] <45_0_0>: <y_0_0>[C] >= 1;
+  [linear] <45_1_0>: <y_1_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/indexing_00.txt
+++ b/tests/snapshots/scip/indexing_00.txt
@@ -7,19 +7,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_01.txt
+++ b/tests/snapshots/scip/indexing_01.txt
@@ -7,19 +7,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_02.txt
+++ b/tests/snapshots/scip/indexing_02.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_03.txt
+++ b/tests/snapshots/scip/indexing_03.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_2
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0 +1 m_0_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_04.txt
+++ b/tests/snapshots/scip/indexing_04.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_2
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0 +1 m_0_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_05.txt
+++ b/tests/snapshots/scip/indexing_05.txt
@@ -7,19 +7,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_06.txt
+++ b/tests/snapshots/scip/indexing_06.txt
@@ -7,19 +7,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_07.txt
+++ b/tests/snapshots/scip/indexing_07.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_2
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0 +1 m_0_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_08.txt
+++ b/tests/snapshots/scip/indexing_08.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_2
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0 +1 m_0_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_09.txt
+++ b/tests/snapshots/scip/indexing_09.txt
@@ -7,19 +7,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_10.txt
+++ b/tests/snapshots/scip/indexing_10.txt
@@ -7,19 +7,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_11.txt
+++ b/tests/snapshots/scip/indexing_11.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_2
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0 +1 m_0_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_12.txt
+++ b/tests/snapshots/scip/indexing_12.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_2
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0 +1 m_0_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=0, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_13.txt
+++ b/tests/snapshots/scip/indexing_13.txt
@@ -7,19 +7,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_14.txt
+++ b/tests/snapshots/scip/indexing_14.txt
@@ -7,19 +7,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1 +3
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +3
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/indexing_15.txt
+++ b/tests/snapshots/scip/indexing_15.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 m_0_0 +1 m_0_1 +1 m_1_0 +1 m_1_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <m_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <m_1_1>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/matrix_00.txt
+++ b/tests/snapshots/scip/matrix_00.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 7_0: +1 x_0 >= +1
- 7_1: +1 x_1 >= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <7_0>: <x_0>[C] >= 1;
+  [linear] <7_1>: <x_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/matrix_01.txt
+++ b/tests/snapshots/scip/matrix_01.txt
@@ -9,27 +9,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: +1 x_0 <= +2
- c4: +1 x_1 <= +2
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>: <x_0>[C] <= 2;
+  [linear] <c4>: <x_1>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 13_0: +1 x_0 >= +1
- 13_1: +1 x_1 >= +1
- 18_0: +1 x_0 <= +2
- 18_1: +1 x_1 <= +2
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <13_0>: <x_0>[C] >= 1;
+  [linear] <13_1>: <x_1>[C] >= 1;
+  [linear] <18_0>: <x_0>[C] <= 2;
+  [linear] <18_1>: <x_1>[C] <= 2;
+END

--- a/tests/snapshots/scip/matrix_02.txt
+++ b/tests/snapshots/scip/matrix_02.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_0 = +1
- c2: +1 x_1 = +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+  [linear] <c2>: <x_1>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 24_0: +1 x_0 = +1
- 24_1: +1 x_1 = +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <24_0>: <x_0>[C] == 1;
+  [linear] <24_1>: <x_1>[C] == 1;
+END

--- a/tests/snapshots/scip/matrix_03.txt
+++ b/tests/snapshots/scip/matrix_03.txt
@@ -10,31 +10,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_0 = +1
- c2: +1 x_1 = +1
- c3: +1 x_2 = +1
- c4: +1 x_3 = +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+  [linear] <c2>: <x_1>[C] == 1;
+  [linear] <c3>: <x_2>[C] == 1;
+  [linear] <c4>: <x_3>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 30_0: +1 x_0 = +1
- 30_1: +1 x_1 = +1
- 35_0: +1 y_0 = +1
- 35_1: +1 y_1 = +1
-Bounds
- x_0 free
- x_1 free
- y_0 free
- y_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <30_0>: <x_0>[C] == 1;
+  [linear] <30_1>: <x_1>[C] == 1;
+  [linear] <35_0>: <y_0>[C] == 1;
+  [linear] <35_1>: <y_1>[C] == 1;
+END

--- a/tests/snapshots/scip/matrix_04.txt
+++ b/tests/snapshots/scip/matrix_04.txt
@@ -10,31 +10,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_2 = +0
- c2: +1 x_3 = +0
- c3: -1 x_0 -1 x_2 <= -1
- c4: -1 x_1 -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_2>[C] == 0;
+  [linear] <c2>: <x_3>[C] == 0;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 42_0: +1 x_0 +1 y_0 >= +1
- 42_1: +1 x_1 +1 y_1 >= +1
- 47_0: +1 y_0 = +0
- 47_1: +1 y_1 = +0
-Bounds
- x_0 free
- x_1 free
- y_0 free
- y_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <42_0>: <x_0>[C] +<y_0>[C] >= 1;
+  [linear] <42_1>: <x_1>[C] +<y_1>[C] >= 1;
+  [linear] <47_0>: <y_0>[C] == 0;
+  [linear] <47_1>: <y_1>[C] == 0;
+END

--- a/tests/snapshots/scip/matrix_05.txt
+++ b/tests/snapshots/scip/matrix_05.txt
@@ -10,31 +10,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_2 = +0
- c2: +1 x_3 = +0
- c3: -1 x_0 -1 x_2 <= +1
- c4: -1 x_1 -1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_2>[C] == 0;
+  [linear] <c2>: <x_3>[C] == 0;
+  [linear] <c3>:  -<x_0>[C] -<x_2>[C] <= 1;
+  [linear] <c4>:  -<x_1>[C] -<x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 56_0: +1 x_0 +1 y_0 >= -1
- 56_1: +1 x_1 +1 y_1 >= -1
- 61_0: +1 y_0 = +0
- 61_1: +1 y_1 = +0
-Bounds
- x_0 free
- x_1 free
- y_0 free
- y_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <56_0>: <x_0>[C] +<y_0>[C] >= -1;
+  [linear] <56_1>: <x_1>[C] +<y_1>[C] >= -1;
+  [linear] <61_0>: <y_0>[C] == 0;
+  [linear] <61_1>: <y_1>[C] == 0;
+END

--- a/tests/snapshots/scip/matrix_06.txt
+++ b/tests/snapshots/scip/matrix_06.txt
@@ -9,23 +9,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_1 = +1
- c2: +2 x_0 +3 x_1 = +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] == 1;
+  [linear] <c2>:  +2<x_0>[C] +3<x_1>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 68_0: +1 x_1 = +1
- 68_1: +2 x_0 +3 x_1 = +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <68_0>: <x_1>[C] == 1;
+  [linear] <68_1>:  +2<x_0>[C] +3<x_1>[C] == 1;
+END

--- a/tests/snapshots/scip/matrix_07.txt
+++ b/tests/snapshots/scip/matrix_07.txt
@@ -11,31 +11,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_1 +1 x_2 = +1
- c2: +2 x_0 +3 x_1 +1 x_3 = +1
- c3: +1 x_2 = +0
- c4: +1 x_3 = +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] +<x_2>[C] == 1;
+  [linear] <c2>:  +2<x_0>[C] +3<x_1>[C] +<x_3>[C] == 1;
+  [linear] <c3>: <x_2>[C] == 0;
+  [linear] <c4>: <x_3>[C] == 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 76_0: +1 x_1 +1 y_0 = +1
- 76_1: +2 x_0 +3 x_1 +1 y_1 = +1
- 81_0: +1 y_0 = +0
- 81_1: +1 y_1 = +0
-Bounds
- x_0 free
- x_1 free
- y_0 free
- y_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <76_0>: <x_1>[C] +<y_0>[C] == 1;
+  [linear] <76_1>:  +2<x_0>[C] +3<x_1>[C] +<y_1>[C] == 1;
+  [linear] <81_0>: <y_0>[C] == 0;
+  [linear] <81_1>: <y_1>[C] == 0;
+END

--- a/tests/snapshots/scip/matrix_08.txt
+++ b/tests/snapshots/scip/matrix_08.txt
@@ -11,31 +11,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_1 +1 x_2 = -1
- c2: +2 x_0 +3 x_1 +1 x_3 = -1
- c3: +1 x_2 = +0
- c4: +1 x_3 = +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] +<x_2>[C] == -1;
+  [linear] <c2>:  +2<x_0>[C] +3<x_1>[C] +<x_3>[C] == -1;
+  [linear] <c3>: <x_2>[C] == 0;
+  [linear] <c4>: <x_3>[C] == 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 91_0: +1 x_1 +1 y_0 = -1
- 91_1: +2 x_0 +3 x_1 +1 y_1 = -1
- 96_0: +1 y_0 = +0
- 96_1: +1 y_1 = +0
-Bounds
- x_0 free
- x_1 free
- y_0 free
- y_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <91_0>: <x_1>[C] +<y_0>[C] == -1;
+  [linear] <91_1>:  +2<x_0>[C] +3<x_1>[C] +<y_1>[C] == -1;
+  [linear] <96_0>: <y_0>[C] == 0;
+  [linear] <96_1>: <y_1>[C] == 0;
+END

--- a/tests/snapshots/scip/matrix_09.txt
+++ b/tests/snapshots/scip/matrix_09.txt
@@ -9,23 +9,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_1 = +1
- c2: +2 x_0 +3 x_1 = +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] == 1;
+  [linear] <c2>:  +2<x_0>[C] +3<x_1>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 103_0: +1 x_1 = +1
- 103_1: +2 x_0 +3 x_1 = +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <103_0>: <x_1>[C] == 1;
+  [linear] <103_1>:  +2<x_0>[C] +3<x_1>[C] == 1;
+END

--- a/tests/snapshots/scip/matrix_10.txt
+++ b/tests/snapshots/scip/matrix_10.txt
@@ -11,31 +11,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_1 +1 x_2 = +1
- c2: +2 x_0 +3 x_1 +1 x_3 = +1
- c3: +1 x_2 = +0
- c4: +1 x_3 = +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] +<x_2>[C] == 1;
+  [linear] <c2>:  +2<x_0>[C] +3<x_1>[C] +<x_3>[C] == 1;
+  [linear] <c3>: <x_2>[C] == 0;
+  [linear] <c4>: <x_3>[C] == 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 111_0: +1 x_1 +1 y_0 = +1
- 111_1: +2 x_0 +3 x_1 +1 y_1 = +1
- 116_0: +1 y_0 = +0
- 116_1: +1 y_1 = +0
-Bounds
- x_0 free
- x_1 free
- y_0 free
- y_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <111_0>: <x_1>[C] +<y_0>[C] == 1;
+  [linear] <111_1>:  +2<x_0>[C] +3<x_1>[C] +<y_1>[C] == 1;
+  [linear] <116_0>: <y_0>[C] == 0;
+  [linear] <116_1>: <y_1>[C] == 0;
+END

--- a/tests/snapshots/scip/matrix_11.txt
+++ b/tests/snapshots/scip/matrix_11.txt
@@ -11,31 +11,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 x_1 +1 x_2 = -1
- c2: +2 x_0 +3 x_1 +1 x_3 = -1
- c3: +1 x_2 = +0
- c4: +1 x_3 = +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] +<x_2>[C] == -1;
+  [linear] <c2>:  +2<x_0>[C] +3<x_1>[C] +<x_3>[C] == -1;
+  [linear] <c3>: <x_2>[C] == 0;
+  [linear] <c4>: <x_3>[C] == 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 126_0: +1 x_1 +1 y_0 = -1
- 126_1: +2 x_0 +3 x_1 +1 y_1 = -1
- 131_0: +1 y_0 = +0
- 131_1: +1 y_1 = +0
-Bounds
- x_0 free
- x_1 free
- y_0 free
- y_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <126_0>: <x_1>[C] +<y_0>[C] == -1;
+  [linear] <126_1>:  +2<x_0>[C] +3<x_1>[C] +<y_1>[C] == -1;
+  [linear] <131_0>: <y_0>[C] == 0;
+  [linear] <131_1>: <y_1>[C] == 0;
+END

--- a/tests/snapshots/scip/matrix_quadratic_00.txt
+++ b/tests/snapshots/scip/matrix_quadratic_00.txt
@@ -7,30 +7,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 +1 x_0 = +1
- c3: +1 soc_t_2 -2 x_1 = +0
- c4: +1 soc_t_3 -2 x_2 = +0
- c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] +<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c5>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +0
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x_0>*<x_0>-<x_1>*<x_1> >= 0;
+END

--- a/tests/snapshots/scip/matrix_quadratic_01.txt
+++ b/tests/snapshots/scip/matrix_quadratic_01.txt
@@ -7,30 +7,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 +1 x_0 = +1
- c3: +1 soc_t_2 -2 x_1 = -2
- c4: +1 soc_t_3 -2 x_2 = -2
- c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] +<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == -2;
+  [linear] <c4>: <soc_t_3>[C] -2<x_2>[C] == -2;
+  [nonlinear] <c5>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 +2 x_0 +2 x_1 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +2
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x_0>*<x_0>+2*<x_0>-<x_1>*<x_1>+2*<x_1> >= 2;
+END

--- a/tests/snapshots/scip/matrix_quadratic_02.txt
+++ b/tests/snapshots/scip/matrix_quadratic_02.txt
@@ -8,30 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_2 <= +1
- c2: +1 soc_t_1 -1 x_2 = +1
- c3: +1 soc_t_2 +1 x_2 = +1
- c4: +1 soc_t_3 -2 x_0 = +0
- c5: +1 soc_t_4 -2 x_1 = +0
- c6: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_1 * soc_t_1 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_2 free
- soc_t_3 free
- soc_t_4 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_2>[C] <= 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_2>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] +<x_2>[C] == 1;
+  [linear] <c4>: <soc_t_3>[C] -2<x_0>[C] == 0;
+  [linear] <c5>: <soc_t_4>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c6>: <soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>+<soc_t_4>*<soc_t_4>-<soc_t_1>*<soc_t_1> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 11: + [ +1 x_0 * x_0 +1 x_1 * x_1 ] <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <11>: <x_0>*<x_0>+<x_1>*<x_1> <= 1;
+END

--- a/tests/snapshots/scip/matrix_quadratic_03.txt
+++ b/tests/snapshots/scip/matrix_quadratic_03.txt
@@ -8,41 +8,43 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 x_3 <= +1
- c2: +1 soc_t_1 -1 x_0 = +1
- c3: +1 soc_t_2 +1 x_0 = +1
- c4: +1 soc_t_3 -2 x_1 = +0
- c5: +1 soc_t_4 -2 x_2 = +0
- c6: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_1 * soc_t_1 ] <= +0
- c7: +1 soc_t_5 -1 x_3 = +1
- c8: +1 soc_t_6 +1 x_3 = +1
- c9: +1 soc_t_7 -2 x_1 = +0
- c10: +1 soc_t_8 -2 x_2 = +0
- c11: + [ +1 soc_t_6 * soc_t_6 +1 soc_t_7 * soc_t_7 +1 soc_t_8 * soc_t_8 -1 soc_t_5 * soc_t_5 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- soc_t_2 free
- soc_t_3 free
- soc_t_4 free
- soc_t_6 free
- soc_t_7 free
- soc_t_8 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_8>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_3>[C] <= 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] +<x_0>[C] == 1;
+  [linear] <c4>: <soc_t_3>[C] -2<x_1>[C] == 0;
+  [linear] <c5>: <soc_t_4>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c6>: <soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>+<soc_t_4>*<soc_t_4>-<soc_t_1>*<soc_t_1> <= 0;
+  [linear] <c7>: <soc_t_5>[C] -<x_3>[C] == 1;
+  [linear] <c8>: <soc_t_6>[C] +<x_3>[C] == 1;
+  [linear] <c9>: <soc_t_7>[C] -2<x_1>[C] == 0;
+  [linear] <c10>: <soc_t_8>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c11>: <soc_t_6>*<soc_t_6>+<soc_t_7>*<soc_t_7>+<soc_t_8>*<soc_t_8>-<soc_t_5>*<soc_t_5> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +0
- 17: + [ +1 x_0 * x_0 +1 x_1 * x_1 ] <= +1
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x_0>*<x_0>-<x_1>*<x_1> >= 0;
+  [nonlinear] <17>: <x_0>*<x_0>+<x_1>*<x_1> <= 1;
+END

--- a/tests/snapshots/scip/matrix_quadratic_04.txt
+++ b/tests/snapshots/scip/matrix_quadratic_04.txt
@@ -8,30 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 +1 x_0 = +1
- c3: +1 soc_t_2 -4 x_1 = +0
- c4: +1 soc_t_3 -4 x_2 = +0
- c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] +<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -4<x_1>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -4<x_2>[C] == 0;
+  [nonlinear] <c5>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -4 x_0 * x_0 -4 x_1 * x_1 ] >= +0
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-4*<x_0>*<x_0>-4*<x_1>*<x_1> >= 0;
+END

--- a/tests/snapshots/scip/matrix_quadratic_05.txt
+++ b/tests/snapshots/scip/matrix_quadratic_05.txt
@@ -8,30 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 +1 x_0 = +1
- c3: +1 soc_t_2 -4 x_1 = +0
- c4: +1 soc_t_3 -4 x_2 = +0
- c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] +<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -4<x_1>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -4<x_2>[C] == 0;
+  [nonlinear] <c5>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -4 x_0 * x_0 -4 x_1 * x_1 ] >= +0
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-4*<x_0>*<x_0>-4*<x_1>*<x_1> >= 0;
+END

--- a/tests/snapshots/scip/matrix_quadratic_constraints_00.txt
+++ b/tests/snapshots/scip/matrix_quadratic_constraints_00.txt
@@ -8,37 +8,41 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
- c5: +1 soc_t_4 -1 x_2 = +1
- c6: +1 soc_t_5 -1 x_2 = -1
- c7: +1 soc_t_6 -2 x_0 = +0
- c8: + [ +1 soc_t_5 * soc_t_5 +1 soc_t_6 * soc_t_6 -1 soc_t_4 * soc_t_4 ] <= +0
- c9: +1 soc_t_7 -1 x_3 = +1
- c10: +1 soc_t_8 -1 x_3 = -1
- c11: +1 soc_t_9 -2 x_1 = +0
- c12: + [ +1 soc_t_8 * soc_t_8 +1 soc_t_9 * soc_t_9 -1 soc_t_7 * soc_t_7 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- soc_t_5 free
- soc_t_6 free
- soc_t_8 free
- soc_t_9 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_7>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_8>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_9>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+  [linear] <c5>: <soc_t_4>[C] -<x_2>[C] == 1;
+  [linear] <c6>: <soc_t_5>[C] -<x_2>[C] == -1;
+  [linear] <c7>: <soc_t_6>[C] -2<x_0>[C] == 0;
+  [nonlinear] <c8>: <soc_t_5>*<soc_t_5>+<soc_t_6>*<soc_t_6>-<soc_t_4>*<soc_t_4> <= 0;
+  [linear] <c9>: <soc_t_7>[C] -<x_3>[C] == 1;
+  [linear] <c10>: <soc_t_8>[C] -<x_3>[C] == -1;
+  [linear] <c11>: <soc_t_9>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c12>: <soc_t_8>*<soc_t_8>+<soc_t_9>*<soc_t_9>-<soc_t_7>*<soc_t_7> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 8_0: + [ +1 x_0 * x_0 ] <= +1
- 8_1: + [ +1 x_1 * x_1 ] <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <8_0>: <x_0>*<x_0> <= 1;
+  [nonlinear] <8_1>: <x_1>*<x_1> <= 1;
+END

--- a/tests/snapshots/scip/matrix_quadratic_constraints_01.txt
+++ b/tests/snapshots/scip/matrix_quadratic_constraints_01.txt
@@ -8,59 +8,67 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
- c5: +1 x_4 <= +1
- c6: +1 x_5 <= +1
- c7: +1 x_6 <= +1
- c8: +1 x_7 <= +1
- c9: +1 soc_t_8 -1 x_4 = +1
- c10: +1 soc_t_9 -1 x_4 = -1
- c11: +1 soc_t_10 -2 x_0 = +0
- c12: + [ +1 soc_t_9 * soc_t_9 +1 soc_t_10 * soc_t_10 -1 soc_t_8 * soc_t_8 ] <= +0
- c13: +1 soc_t_11 -1 x_5 = +1
- c14: +1 soc_t_12 -1 x_5 = -1
- c15: +1 soc_t_13 -2 x_1 = +0
- c16: + [ +1 soc_t_12 * soc_t_12 +1 soc_t_13 * soc_t_13 -1 soc_t_11 * soc_t_11 ] <= +0
- c17: +1 soc_t_14 -1 x_6 = +1
- c18: +1 soc_t_15 -1 x_6 = -1
- c19: +1 soc_t_16 -2 x_2 = +0
- c20: + [ +1 soc_t_15 * soc_t_15 +1 soc_t_16 * soc_t_16 -1 soc_t_14 * soc_t_14 ] <= +0
- c21: +1 soc_t_17 -1 x_7 = +1
- c22: +1 soc_t_18 -1 x_7 = -1
- c23: +1 soc_t_19 -2 x_3 = +0
- c24: + [ +1 soc_t_18 * soc_t_18 +1 soc_t_19 * soc_t_19 -1 soc_t_17 * soc_t_17 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
- x_6 free
- x_7 free
- soc_t_9 free
- soc_t_10 free
- soc_t_12 free
- soc_t_13 free
- soc_t_15 free
- soc_t_16 free
- soc_t_18 free
- soc_t_19 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_7>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_8>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_9>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_10>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_11>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_12>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_13>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_14>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_15>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_16>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_17>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_18>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_19>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+  [linear] <c5>: <x_4>[C] <= 1;
+  [linear] <c6>: <x_5>[C] <= 1;
+  [linear] <c7>: <x_6>[C] <= 1;
+  [linear] <c8>: <x_7>[C] <= 1;
+  [linear] <c9>: <soc_t_8>[C] -<x_4>[C] == 1;
+  [linear] <c10>: <soc_t_9>[C] -<x_4>[C] == -1;
+  [linear] <c11>: <soc_t_10>[C] -2<x_0>[C] == 0;
+  [nonlinear] <c12>: <soc_t_9>*<soc_t_9>+<soc_t_10>*<soc_t_10>-<soc_t_8>*<soc_t_8> <= 0;
+  [linear] <c13>: <soc_t_11>[C] -<x_5>[C] == 1;
+  [linear] <c14>: <soc_t_12>[C] -<x_5>[C] == -1;
+  [linear] <c15>: <soc_t_13>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c16>: <soc_t_12>*<soc_t_12>+<soc_t_13>*<soc_t_13>-<soc_t_11>*<soc_t_11> <= 0;
+  [linear] <c17>: <soc_t_14>[C] -<x_6>[C] == 1;
+  [linear] <c18>: <soc_t_15>[C] -<x_6>[C] == -1;
+  [linear] <c19>: <soc_t_16>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c20>: <soc_t_15>*<soc_t_15>+<soc_t_16>*<soc_t_16>-<soc_t_14>*<soc_t_14> <= 0;
+  [linear] <c21>: <soc_t_17>[C] -<x_7>[C] == 1;
+  [linear] <c22>: <soc_t_18>[C] -<x_7>[C] == -1;
+  [linear] <c23>: <soc_t_19>[C] -2<x_3>[C] == 0;
+  [nonlinear] <c24>: <soc_t_18>*<soc_t_18>+<soc_t_19>*<soc_t_19>-<soc_t_17>*<soc_t_17> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 y_0_0 +1 y_0_1 +1 y_1_0 +1 y_1_1
-Subject to
- 15_0_0: + [ +1 y_0_0 * y_0_0 ] <= +1
- 15_0_1: + [ +1 y_0_1 * y_0_1 ] <= +1
- 15_1_0: + [ +1 y_1_0 * y_1_0 ] <= +1
- 15_1_1: + [ +1 y_1_1 * y_1_1 ] <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <y_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <y_0_1>: obj=1, original bounds=[0,+inf]
+  [continuous] <y_1_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <y_1_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <15_0_0>: <y_0_0>*<y_0_0> <= 1;
+  [nonlinear] <15_0_1>: <y_0_1>*<y_0_1> <= 1;
+  [nonlinear] <15_1_0>: <y_1_0>*<y_1_0> <= 1;
+  [nonlinear] <15_1_1>: <y_1_1>*<y_1_1> <= 1;
+END

--- a/tests/snapshots/scip/matrix_quadratic_constraints_02.txt
+++ b/tests/snapshots/scip/matrix_quadratic_constraints_02.txt
@@ -9,30 +9,33 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: +13.7082039324994 x_2 <= +1
- c4: +1 soc_t_3 -1 x_2 = +1
- c5: +1 soc_t_4 +1 x_2 = +1
- c6: +1 soc_t_5 +0.248216560693358 x_0 -0.153406271079096 x_1 = +0
- c7: +1 soc_t_6 -1.05146222423827 x_0 -1.70130161670408 x_1 = +0
- c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 +1 soc_t_6 * soc_t_6 -1 soc_t_3 * soc_t_3 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_4 free
- soc_t_5 free
- soc_t_6 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_6>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  +13.7082039324994<x_2>[C] <= 1;
+  [linear] <c4>: <soc_t_3>[C] -<x_2>[C] == 1;
+  [linear] <c5>: <soc_t_4>[C] +<x_2>[C] == 1;
+  [linear] <c6>: <soc_t_5>[C] +0.248216560693358<x_0>[C] -0.153406271079096<x_1>[C] == 0;
+  [linear] <c7>: <soc_t_6>[C] -1.05146222423827<x_0>[C] -1.70130161670408<x_1>[C] == 0;
+  [nonlinear] <c8>: <soc_t_4>*<soc_t_4>+<soc_t_5>*<soc_t_5>+<soc_t_6>*<soc_t_6>-<soc_t_3>*<soc_t_3> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 21: + [ +4 x_0 * x_0 +12 x_0 * x_1 +10 x_1 * x_1 ] <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <21>: 4*<x_0>*<x_0>+12*<x_0>*<x_1>+10*<x_1>*<x_1> <= 1;
+END

--- a/tests/snapshots/scip/matrix_quadratic_constraints_03.txt
+++ b/tests/snapshots/scip/matrix_quadratic_constraints_03.txt
@@ -9,30 +9,33 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: +1 x_2 <= +1
- c4: +1 soc_t_3 -1 x_2 = +1
- c5: +1 soc_t_4 +1 x_2 = +1
- c6: +1 soc_t_5 -4 x_0 -6 x_1 = +0
- c7: +1 soc_t_6 -2 x_1 = +0
- c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 +1 soc_t_6 * soc_t_6 -1 soc_t_3 * soc_t_3 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_4 free
- soc_t_5 free
- soc_t_6 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_6>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <soc_t_3>[C] -<x_2>[C] == 1;
+  [linear] <c5>: <soc_t_4>[C] +<x_2>[C] == 1;
+  [linear] <c6>: <soc_t_5>[C] -4<x_0>[C] -6<x_1>[C] == 0;
+  [linear] <c7>: <soc_t_6>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c8>: <soc_t_4>*<soc_t_4>+<soc_t_5>*<soc_t_5>+<soc_t_6>*<soc_t_6>-<soc_t_3>*<soc_t_3> <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 27: + [ +4 x_0 * x_0 +12 x_0 * x_1 +10 x_1 * x_1 ] <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[0,+inf]
+CONSTRAINTS
+  [nonlinear] <27>: 4*<x_0>*<x_0>+12*<x_0>*<x_1>+10*<x_1>*<x_1> <= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_00.txt
+++ b/tests/snapshots/scip/nonlinear_exp_00.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: exp((<x>))+<x2>*(-1) <= 0;
- 5: +1 x >= +1
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: exp((<x>))+<x2>*(-1) <= 0;
+  [linear] <5>: <x>[C] >= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_01.txt
+++ b/tests/snapshots/scip/nonlinear_exp_01.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: exp((<x>+1))+<x2>*(-1) <= 0;
- 11: +1 x >= +1
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: exp((<x>+1))+<x2>*(-1) <= 0;
+  [linear] <11>: <x>[C] >= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_02.txt
+++ b/tests/snapshots/scip/nonlinear_exp_02.txt
@@ -11,10 +11,10 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
-\   [nonlinear] <16>: exp((<x>)) <= 1;
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <16>: exp((<x>)) <= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_03.txt
+++ b/tests/snapshots/scip/nonlinear_exp_03.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: exp((<x_0>))+<x2>*(-1) <= 0;
- 5_0: +1 x_0 >= +1
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: exp((<x_0>))+<x2>*(-1) <= 0;
+  [linear] <5_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_04.txt
+++ b/tests/snapshots/scip/nonlinear_exp_04.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: exp((<x_0>+1))+<x2>*(-1) <= 0;
- 11_0: +1 x_0 >= +1
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: exp((<x_0>+1))+<x2>*(-1) <= 0;
+  [linear] <11_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_05.txt
+++ b/tests/snapshots/scip/nonlinear_exp_05.txt
@@ -11,10 +11,10 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
-\   [nonlinear] <16_0>: exp((<x_0>)) <= 1;
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <16_0>: exp((<x_0>)) <= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_06.txt
+++ b/tests/snapshots/scip/nonlinear_exp_06.txt
@@ -11,14 +11,14 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: exp((<x_0>))+exp((<x_1>))+<x3>*(-1) <= 0;
- 7_0: +1 x_0 >= +1
- 7_1: +1 x_1 >= +1
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: exp((<x_0>))+exp((<x_1>))+<x3>*(-1) <= 0;
+  [linear] <7_0>: <x_0>[C] >= 1;
+  [linear] <7_1>: <x_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_07.txt
+++ b/tests/snapshots/scip/nonlinear_exp_07.txt
@@ -11,14 +11,14 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: exp((<x_0>+1))+exp((<x_1>+2))+<x3>*(-1) <= 0;
- 15_0: +1 x_0 >= +1
- 15_1: +1 x_1 >= +1
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: exp((<x_0>+1))+exp((<x_1>+2))+<x3>*(-1) <= 0;
+  [linear] <15_0>: <x_0>[C] >= 1;
+  [linear] <15_1>: <x_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/nonlinear_exp_08.txt
+++ b/tests/snapshots/scip/nonlinear_exp_08.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
-\   [nonlinear] <22_0>: exp((<x_0>)) <= 1;
-\   [nonlinear] <22_1>: exp((<x_1>)) <= 1;
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <22_0>: exp((<x_0>)) <= 1;
+  [nonlinear] <22_1>: exp((<x_1>)) <= 1;
+END

--- a/tests/snapshots/scip/nonlinear_log_00.txt
+++ b/tests/snapshots/scip/nonlinear_log_00.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: log((<x>))+<x2>*(-1) >= 0;
- 5: +1 x <= +2
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: log((<x>))+<x2>*(-1) >= 0;
+  [linear] <5>: <x>[C] <= 2;
+END

--- a/tests/snapshots/scip/nonlinear_log_01.txt
+++ b/tests/snapshots/scip/nonlinear_log_01.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: log((<x>+1))+<x2>*(-1) >= 0;
- 10: +1 x <= +2
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: log((<x>+1))+<x2>*(-1) >= 0;
+  [linear] <10>: <x>[C] <= 2;
+END

--- a/tests/snapshots/scip/nonlinear_log_02.txt
+++ b/tests/snapshots/scip/nonlinear_log_02.txt
@@ -11,10 +11,10 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
-\   [nonlinear] <15>: log((<x>)) >= -1;
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <15>: log((<x>)) >= -1;
+END

--- a/tests/snapshots/scip/nonlinear_log_03.txt
+++ b/tests/snapshots/scip/nonlinear_log_03.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: log((<x_0>))+<x2>*(-1) >= 0;
- 5_0: +1 x_0 <= +0.5
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: log((<x_0>))+<x2>*(-1) >= 0;
+  [linear] <5_0>: <x_0>[C] <= 0.5;
+END

--- a/tests/snapshots/scip/nonlinear_log_04.txt
+++ b/tests/snapshots/scip/nonlinear_log_04.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x2
-Subject to
-\   [nonlinear] <c1>: log((<x_0>+2))+<x2>*(-1) >= 0;
- 11_0: +1 x_0 <= -0.5
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: log((<x_0>+2))+<x2>*(-1) >= 0;
+  [linear] <11_0>: <x_0>[C] <= -0.5;
+END

--- a/tests/snapshots/scip/nonlinear_log_05.txt
+++ b/tests/snapshots/scip/nonlinear_log_05.txt
@@ -11,10 +11,10 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
-\   [nonlinear] <16_0>: log((<x_0>)) >= 1;
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <16_0>: log((<x_0>)) >= 1;
+END

--- a/tests/snapshots/scip/nonlinear_log_06.txt
+++ b/tests/snapshots/scip/nonlinear_log_06.txt
@@ -11,14 +11,14 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: log((<x_0>))+log((<x_1>))+<x3>*(-1) >= 0;
- 7_0: +1 x_0 <= +1
- 7_1: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: log((<x_0>))+log((<x_1>))+<x3>*(-1) >= 0;
+  [linear] <7_0>: <x_0>[C] <= 1;
+  [linear] <7_1>: <x_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/nonlinear_log_07.txt
+++ b/tests/snapshots/scip/nonlinear_log_07.txt
@@ -11,14 +11,14 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x3
-Subject to
-\   [nonlinear] <c1>: log((<x_0>+1))+log((<x_1>+1))+<x3>*(-1) >= 0;
- 14_0: +1 x_0 <= -0.5
- 14_1: +1 x_1 <= -0.5
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: log((<x_0>+1))+log((<x_1>+1))+<x3>*(-1) >= 0;
+  [linear] <14_0>: <x_0>[C] <= -0.5;
+  [linear] <14_1>: <x_1>[C] <= -0.5;
+END

--- a/tests/snapshots/scip/nonlinear_log_08.txt
+++ b/tests/snapshots/scip/nonlinear_log_08.txt
@@ -11,12 +11,12 @@ AFTER COMPILATION
 Either candidate conic solvers (['SCIP']) do not support the cones output by the problem (ExpCone, NonNeg), or there are not enough constraints in the problem.
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
-\   [nonlinear] <21_0>: log((<x_0>)) >= 1;
-\   [nonlinear] <21_1>: log((<x_1>)) >= 1;
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <21_0>: log((<x_0>)) >= 1;
+  [nonlinear] <21_1>: log((<x_1>)) >= 1;
+END

--- a/tests/snapshots/scip/quad_form_00.txt
+++ b/tests/snapshots/scip/quad_form_00.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 +1 x_0 = +1
- c3: +1 soc_t_2 -2 x_1 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] +<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -1 x_0 * x_0 ] >= +0
-Bounds
- x_0 free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-<x_0>*<x_0> >= 0;
+END

--- a/tests/snapshots/scip/quad_form_01.txt
+++ b/tests/snapshots/scip/quad_form_01.txt
@@ -8,30 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +13.7082039324994 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 +1 x_0 = +1
- c3: +1 soc_t_2 +0.248216560693358 x_1 -0.153406271079096 x_2 = +0
- c4: +1 soc_t_3 -1.05146222423827 x_1 -1.70130161670408 x_2 = +0
- c5: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=13.7082039324994, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] +<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] +0.248216560693358<x_1>[C] -0.153406271079096<x_2>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -1.05146222423827<x_1>[C] -1.70130161670408<x_2>[C] == 0;
+  [nonlinear] <c5>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -4 x_0 * x_0 -12 x_0 * x_1 -10 x_1 * x_1 ] >= +0
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-4*<x_0>*<x_0>-12*<x_0>*<x_1>-10*<x_1>*<x_1> >= 0;
+END

--- a/tests/snapshots/scip/quad_form_02.txt
+++ b/tests/snapshots/scip/quad_form_02.txt
@@ -7,23 +7,26 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +2 x_1 +2 x_2 +4 x_3
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=4, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 A_0_0 +2 A_0_1 +2 A_1_0 +4 A_1_1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <A_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <A_0_1>: obj=2, original bounds=[0,+inf]
+  [continuous] <A_1_0>: obj=2, original bounds=[0,+inf]
+  [continuous] <A_1_1>: obj=4, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/quad_form_stack_00.txt
+++ b/tests/snapshots/scip/quad_form_stack_00.txt
@@ -10,35 +10,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 +1 x_0 = +1
- c3: +1 soc_t_2 -2 x_1 = +0
- c4: +1 soc_t_3 -2 x_2 = +0
- c5: +1 soc_t_4 = +2
- c6: +1 soc_t_5 = +4
- c7: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5
-  -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_3 free
- soc_t_4 free
- soc_t_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] +<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == 0;
+  [linear] <c4>: <soc_t_3>[C] -2<x_2>[C] == 0;
+  [linear] <c5>: <soc_t_4>[C] == 2;
+  [linear] <c6>: <soc_t_5>[C] == 4;
+  [nonlinear] <c7>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>+<soc_t_4>*<soc_t_4>+<soc_t_5>*<soc_t_5>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -1 x_0 * x_0 -1 x_1 * x_1 ] >= +5
-Bounds
- x_0 free
- x_1 free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x_0>*<x_0>-<x_1>*<x_1> >= 5;
+END

--- a/tests/snapshots/scip/quadratic_00.txt
+++ b/tests/snapshots/scip/quadratic_00.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_1 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -1 x * x ] >= +0
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-<x>*<x> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_01.txt
+++ b/tests/snapshots/scip/quadratic_01.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_1 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -1 x * x ] >= +1
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-<x>*<x> >= 1;
+END

--- a/tests/snapshots/scip/quadratic_02.txt
+++ b/tests/snapshots/scip/quadratic_02.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_1 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 -1 x + [ -1 x * x ] >= +0
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-<x>*<x>-<x> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_03.txt
+++ b/tests/snapshots/scip/quadratic_03.txt
@@ -7,33 +7,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
- c5: +1 soc_t_3 -1 x_1 = +1
- c6: +1 soc_t_4 -1 x_1 = -1
- c7: +1 soc_t_5 -2 x_2 = +0
- c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_4 free
- soc_t_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+  [linear] <c5>: <soc_t_3>[C] -<x_1>[C] == 1;
+  [linear] <c6>: <soc_t_4>[C] -<x_1>[C] == -1;
+  [linear] <c7>: <soc_t_5>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c8>: <soc_t_4>*<soc_t_4>+<soc_t_5>*<soc_t_5>-<soc_t_3>*<soc_t_3> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -2 x * x ] >= +0
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-2*<x>*<x> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_04.txt
+++ b/tests/snapshots/scip/quadratic_04.txt
@@ -8,35 +8,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
- c5: +1 soc_t_3 -1 x_1 = +1
- c6: +1 soc_t_4 -1 x_1 = -1
- c7: +1 soc_t_5 -2 x_3 = +0
- c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- soc_t_1 free
- soc_t_2 free
- soc_t_4 free
- soc_t_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+  [linear] <c5>: <soc_t_3>[C] -<x_1>[C] == 1;
+  [linear] <c6>: <soc_t_4>[C] -<x_1>[C] == -1;
+  [linear] <c7>: <soc_t_5>[C] -2<x_3>[C] == 0;
+  [nonlinear] <c8>: <soc_t_4>*<soc_t_4>+<soc_t_5>*<soc_t_5>-<soc_t_3>*<soc_t_3> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -1 x * x -1 y * y ] >= +0
-Bounds
- x free
- y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x>*<x>-<y>*<y> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_05.txt
+++ b/tests/snapshots/scip/quadratic_05.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_1 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -2 x * x ] >= +0
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-2*<x>*<x> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_06.txt
+++ b/tests/snapshots/scip/quadratic_06.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -4 x_1 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -4<x_1>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -4 x * x ] >= +0
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-4*<x>*<x> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_07.txt
+++ b/tests/snapshots/scip/quadratic_07.txt
@@ -7,26 +7,27 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -4 x_1 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -4<x_1>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -4 x * x ] >= +1
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-4*<x>*<x> >= 1;
+END

--- a/tests/snapshots/scip/quadratic_08.txt
+++ b/tests/snapshots/scip/quadratic_08.txt
@@ -7,33 +7,35 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -4 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
- c5: +1 soc_t_3 -1 x_1 = +1
- c6: +1 soc_t_4 -1 x_1 = -1
- c7: +1 soc_t_5 -2 x_2 = +0
- c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
- soc_t_4 free
- soc_t_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -4<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+  [linear] <c5>: <soc_t_3>[C] -<x_1>[C] == 1;
+  [linear] <c6>: <soc_t_4>[C] -<x_1>[C] == -1;
+  [linear] <c7>: <soc_t_5>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c8>: <soc_t_4>*<soc_t_4>+<soc_t_5>*<soc_t_5>-<soc_t_3>*<soc_t_3> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -5 x * x ] >= +0
-Bounds
- x free
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-5*<x>*<x> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_09.txt
+++ b/tests/snapshots/scip/quadratic_09.txt
@@ -8,35 +8,37 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -4 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
- c5: +1 soc_t_3 -1 x_1 = +1
- c6: +1 soc_t_4 -1 x_1 = -1
- c7: +1 soc_t_5 -2 x_3 = +0
- c8: + [ +1 soc_t_4 * soc_t_4 +1 soc_t_5 * soc_t_5 -1 soc_t_3 * soc_t_3 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- soc_t_1 free
- soc_t_2 free
- soc_t_4 free
- soc_t_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -4<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+  [linear] <c5>: <soc_t_3>[C] -<x_1>[C] == 1;
+  [linear] <c6>: <soc_t_4>[C] -<x_1>[C] == -1;
+  [linear] <c7>: <soc_t_5>[C] -2<x_3>[C] == 0;
+  [nonlinear] <c8>: <soc_t_4>*<soc_t_4>+<soc_t_5>*<soc_t_5>-<soc_t_3>*<soc_t_3> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -4 x * x -1 y * y ] >= +0
-Bounds
- x free
- y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-4*<x>*<x>-<y>*<y> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_10.txt
+++ b/tests/snapshots/scip/quadratic_10.txt
@@ -8,28 +8,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_1 -2 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -1 x * x -2 x * y -1 y * y ] >= +0
-Bounds
- x free
- y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x>*<x>-2*<x>*<y>-<y>*<y> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_11.txt
+++ b/tests/snapshots/scip/quadratic_11.txt
@@ -8,28 +8,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 soc_t_0 -1 x_0 = +1
- c2: +1 soc_t_1 -1 x_0 = -1
- c3: +1 soc_t_2 -2 x_1 +2 x_2 = +0
- c4: + [ +1 soc_t_1 * soc_t_1 +1 soc_t_2 * soc_t_2 -1 soc_t_0 * soc_t_0 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_1 free
- soc_t_2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_0>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <soc_t_0>[C] -<x_0>[C] == 1;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == -1;
+  [linear] <c3>: <soc_t_2>[C] -2<x_1>[C] +2<x_2>[C] == 0;
+  [nonlinear] <c4>: <soc_t_1>*<soc_t_1>+<soc_t_2>*<soc_t_2>-<soc_t_0>*<soc_t_0> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -1 x * x +2 x * y -1 y * y ] >= +0
-Bounds
- x free
- y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x>*<x>+2*<x>*<y>-<y>*<y> >= 0;
+END

--- a/tests/snapshots/scip/quadratic_12.txt
+++ b/tests/snapshots/scip/quadratic_12.txt
@@ -9,30 +9,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2
-Subject to
- c1: +1 x_2 = +0
- c2: +1 soc_t_1 -1 x_0 = +1
- c3: +1 soc_t_2 -1 x_0 = -1
- c4: +1 soc_t_3 -2 x_1 +2 x_2 = +0
- c5: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_1 * soc_t_1 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_2>[C] == 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -<x_0>[C] == -1;
+  [linear] <c4>: <soc_t_3>[C] -2<x_1>[C] +2<x_2>[C] == 0;
+  [nonlinear] <c5>: <soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_1>*<soc_t_1> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 -1 x -1 y + [ -1 x * x +2 x * y -1 y * y ] >= +0
- 41: +1 y = +0
-Bounds
- x free
- y free
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x>*<x>+2*<x>*<y>-<y>*<y>-<x>-<y> >= 0;
+  [linear] <41>: <y>[C] == 0;
+END

--- a/tests/snapshots/scip/reshape_00.txt
+++ b/tests/snapshots/scip/reshape_00.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 6: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <6>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_01.txt
+++ b/tests/snapshots/scip/reshape_01.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 11_0: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <11_0>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_02.txt
+++ b/tests/snapshots/scip/reshape_02.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 16_0_0: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <16_0_0>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_03.txt
+++ b/tests/snapshots/scip/reshape_03.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 21_0: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <21_0>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_04.txt
+++ b/tests/snapshots/scip/reshape_04.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 26: +1 x <= +0
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <26>: <x>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_05.txt
+++ b/tests/snapshots/scip/reshape_05.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 31_0: +1 x <= +0
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <31_0>: <x>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_06.txt
+++ b/tests/snapshots/scip/reshape_06.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 36_0: +1 x <= +0
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <36_0>: <x>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_07.txt
+++ b/tests/snapshots/scip/reshape_07.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 41_0: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <41_0>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_08.txt
+++ b/tests/snapshots/scip/reshape_08.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
- 6: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <6>: <x_0>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_09.txt
+++ b/tests/snapshots/scip/reshape_09.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
- 11: +1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <11>: <x_0>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_10.txt
+++ b/tests/snapshots/scip/reshape_10.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0
-Subject to
- 16_0: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <16_0>: <x_0>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_11.txt
+++ b/tests/snapshots/scip/reshape_11.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 7_0: +1 x_0 <= +1
- 7_1: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <7_0>: <x_0>[C] <= 1;
+  [linear] <7_1>: <x_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_12.txt
+++ b/tests/snapshots/scip/reshape_12.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 13_0: +1 x_0 <= +1
- 13_1: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <13_0>: <x_0>[C] <= 1;
+  [linear] <13_1>: <x_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_13.txt
+++ b/tests/snapshots/scip/reshape_13.txt
@@ -9,23 +9,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 19_0_0: +1 x_0 <= +1
- 19_1_0: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <19_0_0>: <x_0>[C] <= 1;
+  [linear] <19_1_0>: <x_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_14.txt
+++ b/tests/snapshots/scip/reshape_14.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 25_0_0: +1 x_0 <= +1
- 25_0_1: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <25_0_0>: <x_0>[C] <= 1;
+  [linear] <25_0_1>: <x_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_15.txt
+++ b/tests/snapshots/scip/reshape_15.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 31_0: +1 x_0 <= +0
- 31_1: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <31_0>: <x_0>[C] <= 0;
+  [linear] <31_1>: <x_1>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_16.txt
+++ b/tests/snapshots/scip/reshape_16.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 37_0: +1 x_0 <= +0
- 37_1: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <37_0>: <x_0>[C] <= 0;
+  [linear] <37_1>: <x_1>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_17.txt
+++ b/tests/snapshots/scip/reshape_17.txt
@@ -9,23 +9,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 43_0_0: +1 x_0 <= +0
- 43_1_0: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <43_0_0>: <x_0>[C] <= 0;
+  [linear] <43_1_0>: <x_1>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_18.txt
+++ b/tests/snapshots/scip/reshape_18.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 49_0_0: +1 x_0 <= +0
- 49_0_1: +1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <49_0_0>: <x_0>[C] <= 0;
+  [linear] <49_0_1>: <x_1>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_19.txt
+++ b/tests/snapshots/scip/reshape_19.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1
-Subject to
- 55_0: +1 x_0 <= +0
- 55_1: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <55_0>: <x_0>[C] <= 0;
+  [linear] <55_1>: <x_1>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_20.txt
+++ b/tests/snapshots/scip/reshape_20.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 7_0: +1 x_0 <= +1
- 7_1: +1 x_1 <= +1
- 7_2: +1 x_2 <= +1
- 7_3: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <7_0>: <x_0>[C] <= 1;
+  [linear] <7_1>: <x_1>[C] <= 1;
+  [linear] <7_2>: <x_2>[C] <= 1;
+  [linear] <7_3>: <x_3>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_21.txt
+++ b/tests/snapshots/scip/reshape_21.txt
@@ -11,31 +11,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 13_0_0: +1 x_0 <= +1
- 13_1_0: +1 x_1 <= +1
- 13_2_0: +1 x_2 <= +1
- 13_3_0: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <13_0_0>: <x_0>[C] <= 1;
+  [linear] <13_1_0>: <x_1>[C] <= 1;
+  [linear] <13_2_0>: <x_2>[C] <= 1;
+  [linear] <13_3_0>: <x_3>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_22.txt
+++ b/tests/snapshots/scip/reshape_22.txt
@@ -9,31 +9,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 19_0_0: +1 x_0 <= +1
- 19_0_1: +1 x_1 <= +1
- 19_1_0: +1 x_2 <= +1
- 19_1_1: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <19_0_0>: <x_0>[C] <= 1;
+  [linear] <19_0_1>: <x_1>[C] <= 1;
+  [linear] <19_1_0>: <x_2>[C] <= 1;
+  [linear] <19_1_1>: <x_3>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_23.txt
+++ b/tests/snapshots/scip/reshape_23.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 25_0_0: +1 x_0 <= +1
- 25_0_1: +1 x_1 <= +1
- 25_0_2: +1 x_2 <= +1
- 25_0_3: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <25_0_0>: <x_0>[C] <= 1;
+  [linear] <25_0_1>: <x_1>[C] <= 1;
+  [linear] <25_0_2>: <x_2>[C] <= 1;
+  [linear] <25_0_3>: <x_3>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_24.txt
+++ b/tests/snapshots/scip/reshape_24.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
- c3: +1 x_2 <= +0
- c4: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 0;
+  [linear] <c4>: <x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 31_0: +1 x_0 <= +0
- 31_1: +1 x_1 <= +0
- 31_2: +1 x_2 <= +0
- 31_3: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <31_0>: <x_0>[C] <= 0;
+  [linear] <31_1>: <x_1>[C] <= 0;
+  [linear] <31_2>: <x_2>[C] <= 0;
+  [linear] <31_3>: <x_3>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_25.txt
+++ b/tests/snapshots/scip/reshape_25.txt
@@ -11,31 +11,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
- c3: +1 x_2 <= +0
- c4: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 0;
+  [linear] <c4>: <x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 37_0_0: +1 x_0 <= +0
- 37_1_0: +1 x_1 <= +0
- 37_2_0: +1 x_2 <= +0
- 37_3_0: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <37_0_0>: <x_0>[C] <= 0;
+  [linear] <37_1_0>: <x_1>[C] <= 0;
+  [linear] <37_2_0>: <x_2>[C] <= 0;
+  [linear] <37_3_0>: <x_3>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_26.txt
+++ b/tests/snapshots/scip/reshape_26.txt
@@ -9,31 +9,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
- c3: +1 x_2 <= +0
- c4: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 0;
+  [linear] <c4>: <x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 43_0_0: +1 x_0 <= +0
- 43_0_1: +1 x_1 <= +0
- 43_1_0: +1 x_2 <= +0
- 43_1_1: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <43_0_0>: <x_0>[C] <= 0;
+  [linear] <43_0_1>: <x_1>[C] <= 0;
+  [linear] <43_1_0>: <x_2>[C] <= 0;
+  [linear] <43_1_1>: <x_3>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_27.txt
+++ b/tests/snapshots/scip/reshape_27.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +0
- c3: +1 x_2 <= +0
- c4: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 0;
+  [linear] <c3>: <x_2>[C] <= 0;
+  [linear] <c4>: <x_3>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 49_0_0: +1 x_0 <= +0
- 49_0_1: +1 x_1 <= +0
- 49_0_2: +1 x_2 <= +0
- 49_0_3: +1 x_3 <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <49_0_0>: <x_0>[C] <= 0;
+  [linear] <49_0_1>: <x_1>[C] <= 0;
+  [linear] <49_0_2>: <x_2>[C] <= 0;
+  [linear] <49_0_3>: <x_3>[C] <= 0;
+END

--- a/tests/snapshots/scip/reshape_28.txt
+++ b/tests/snapshots/scip/reshape_28.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +1
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +1
- c4: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 1;
+  [linear] <c4>: <x_3>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 56_0_0: +1 x_0 <= +1
- 56_0_1: +1 x_1 <= +1
- 56_1_0: +1 x_2 <= +1
- 56_1_1: +1 x_3 <= +1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <56_0_0>: <x_0>[C] <= 1;
+  [linear] <56_0_1>: <x_1>[C] <= 1;
+  [linear] <56_1_0>: <x_2>[C] <= 1;
+  [linear] <56_1_1>: <x_3>[C] <= 1;
+END

--- a/tests/snapshots/scip/reshape_29.txt
+++ b/tests/snapshots/scip/reshape_29.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0 -1 x_1 -1 x_2 -1 x_3
-Subject to
- c1: +1 x_0 <= +0
- c2: +1 x_1 <= +1
- c3: +1 x_2 <= +2
- c4: +1 x_3 <= +3
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 0;
+  [linear] <c2>: <x_1>[C] <= 1;
+  [linear] <c3>: <x_2>[C] <= 2;
+  [linear] <c4>: <x_3>[C] <= 3;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- 62_0: +1 x_0 <= +0
- 62_1: +1 x_1 <= +1
- 62_2: +1 x_2 <= +2
- 62_3: +1 x_3 <= +3
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <62_0>: <x_0>[C] <= 0;
+  [linear] <62_1>: <x_1>[C] <= 1;
+  [linear] <62_2>: <x_2>[C] <= 2;
+  [linear] <62_3>: <x_3>[C] <= 3;
+END

--- a/tests/snapshots/scip/reshape_30.txt
+++ b/tests/snapshots/scip/reshape_30.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/reshape_31.txt
+++ b/tests/snapshots/scip/reshape_31.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +2.5
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +2.5
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/scalar_linear_00.txt
+++ b/tests/snapshots/scip/scalar_linear_00.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 5: +1 x >= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <5>: <x>[C] >= 1;
+END

--- a/tests/snapshots/scip/scalar_linear_01.txt
+++ b/tests/snapshots/scip/scalar_linear_01.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 9: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <9>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/scalar_linear_02.txt
+++ b/tests/snapshots/scip/scalar_linear_02.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 x_0 = +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 13: +1 x = +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <13>: <x>[C] == 1;
+END

--- a/tests/snapshots/scip/scalar_linear_03.txt
+++ b/tests/snapshots/scip/scalar_linear_03.txt
@@ -9,21 +9,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
- c2: +1 x_0 <= +2
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>: <x_0>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 17: +1 x >= +1
- 21: +1 x <= +2
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <17>: <x>[C] >= 1;
+  [linear] <21>: <x>[C] <= 2;
+END

--- a/tests/snapshots/scip/scalar_linear_04.txt
+++ b/tests/snapshots/scip/scalar_linear_04.txt
@@ -9,21 +9,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
- c2: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 25: +1 x >= +1
- 29: +1 x <= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <25>: <x>[C] >= 1;
+  [linear] <29>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/scalar_linear_05.txt
+++ b/tests/snapshots/scip/scalar_linear_05.txt
@@ -10,23 +10,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 x_0 = +1
- c2: -1 x_0 <= +0
- c3: +1 x_0 <= +2
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+  [linear] <c2>:  -<x_0>[C] <= 0;
+  [linear] <c3>: <x_0>[C] <= 2;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 33: +1 x >= +0
- 37: +1 x <= +2
- 41: +1 x = +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <33>: <x>[C] >= 0;
+  [linear] <37>: <x>[C] <= 2;
+  [linear] <41>: <x>[C] == 1;
+END

--- a/tests/snapshots/scip/scalar_linear_06.txt
+++ b/tests/snapshots/scip/scalar_linear_06.txt
@@ -10,23 +10,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 45: +1 x >= +1
- 49: +1 y >= +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <45>: <x>[C] >= 1;
+  [linear] <49>: <y>[C] >= 1;
+END

--- a/tests/snapshots/scip/scalar_linear_07.txt
+++ b/tests/snapshots/scip/scalar_linear_07.txt
@@ -10,23 +10,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 x_0 = +1
- c2: +1 x_1 = +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] == 1;
+  [linear] <c2>: <x_1>[C] == 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 53: +1 x = +1
- 57: +1 y = +1
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <53>: <x>[C] == 1;
+  [linear] <57>: <y>[C] == 1;
+END

--- a/tests/snapshots/scip/scalar_linear_08.txt
+++ b/tests/snapshots/scip/scalar_linear_08.txt
@@ -10,23 +10,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 x_1 = +0
- c2: -1 x_0 -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] == 0;
+  [linear] <c2>:  -<x_0>[C] -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 62: +1 x +1 y >= +1
- 66: +1 y = +0
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <62>: <x>[C] +<y>[C] >= 1;
+  [linear] <66>: <y>[C] == 0;
+END

--- a/tests/snapshots/scip/scalar_linear_09.txt
+++ b/tests/snapshots/scip/scalar_linear_09.txt
@@ -10,23 +10,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: +1 x_1 = +0
- c2: +1 x_0 +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] == 0;
+  [linear] <c2>: <x_0>[C] +<x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Maximize
- Obj: +1 x
-Subject to
- 71: +1 x +1 y <= +1
- 75: +1 y = +0
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : maximize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <71>: <x>[C] +<y>[C] <= 1;
+  [linear] <75>: <y>[C] == 0;
+END

--- a/tests/snapshots/scip/scalar_linear_10.txt
+++ b/tests/snapshots/scip/scalar_linear_10.txt
@@ -10,23 +10,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 x_0 +1 x_1 = +1
- c2: +1 x_1 = +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_0>[C] +<x_1>[C] == 1;
+  [linear] <c2>: <x_1>[C] == 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 80: +1 x +1 y = +1
- 84: +1 y = +0
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <80>: <x>[C] +<y>[C] == 1;
+  [linear] <84>: <y>[C] == 0;
+END

--- a/tests/snapshots/scip/scalar_linear_11.txt
+++ b/tests/snapshots/scip/scalar_linear_11.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -2 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -2<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 89: +2 x >= +1
-Bounds
- x free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <89>:  +2<x>[C] >= 1;
+END

--- a/tests/snapshots/scip/scalar_linear_12.txt
+++ b/tests/snapshots/scip/scalar_linear_12.txt
@@ -10,23 +10,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: +1 x_1 = +0
- c2: -2 x_0 -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>: <x_1>[C] == 0;
+  [linear] <c2>:  -2<x_0>[C] -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
- 95: +2 x +1 y >= +1
- 99: +1 y = +0
-Bounds
- x free
- y free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <95>:  +2<x>[C] +<y>[C] >= 1;
+  [linear] <99>: <y>[C] == 0;
+END

--- a/tests/snapshots/scip/scalar_stack_00.txt
+++ b/tests/snapshots/scip/scalar_stack_00.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/scalar_stack_01.txt
+++ b/tests/snapshots/scip/scalar_stack_01.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_00.txt
+++ b/tests/snapshots/scip/simple_00.txt
@@ -7,17 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_01.txt
+++ b/tests/snapshots/scip/simple_01.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_02.txt
+++ b/tests/snapshots/scip/simple_02.txt
@@ -7,17 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=2, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_03.txt
+++ b/tests/snapshots/scip/simple_03.txt
@@ -8,19 +8,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1 y
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+  [continuous] <y>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_04.txt
+++ b/tests/snapshots/scip/simple_04.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x -1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : -1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_05.txt
+++ b/tests/snapshots/scip/simple_05.txt
@@ -9,21 +9,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 -1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: +1 x_1 <= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>: <x_1>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x -1 y
-Subject to
- 12: +1 y <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+  [continuous] <y>: obj=-1, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <12>: <y>[C] <= 1;
+END

--- a/tests/snapshots/scip/simple_06.txt
+++ b/tests/snapshots/scip/simple_06.txt
@@ -7,17 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=2, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_07.txt
+++ b/tests/snapshots/scip/simple_07.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=2, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_08.txt
+++ b/tests/snapshots/scip/simple_08.txt
@@ -8,19 +8,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x +1 y
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=2, original bounds=[0,+inf]
+  [continuous] <y>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_09.txt
+++ b/tests/snapshots/scip/simple_09.txt
@@ -8,19 +8,20 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: -1 x
-Subject to
- 22: +1 x <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=-1, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <22>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/simple_10.txt
+++ b/tests/snapshots/scip/simple_10.txt
@@ -8,19 +8,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: -1 x +1
-Subject to
- 28: +1 x <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=-1, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <28>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/simple_11.txt
+++ b/tests/snapshots/scip/simple_11.txt
@@ -8,19 +8,21 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: -1 x_0
-Subject to
- c1: -1 x_0 <= +0
- c2: +1 x_0 <= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=-1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>: <x_0>[C] <= 1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: -1 x +1
-Subject to
- 34: +1 x <= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=-1, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <34>: <x>[C] <= 1;
+END

--- a/tests/snapshots/scip/simple_12.txt
+++ b/tests/snapshots/scip/simple_12.txt
@@ -7,17 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +0.5 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0.5, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +0.5 x
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0.5, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_13.txt
+++ b/tests/snapshots/scip/simple_13.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +0.5 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=0.5, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +0.5 x +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=0.5, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/simple_14.txt
+++ b/tests/snapshots/scip/simple_14.txt
@@ -7,26 +7,28 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_1 <= +0
- c2: +1 soc_t_1 -1 x_0 = +1
- c3: +1 soc_t_2 -1 x_0 = -1
- c4: +1 soc_t_3 -2 x_1 = +0
- c5: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_1 * soc_t_1 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_1>[C] <= 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -<x_0>[C] == -1;
+  [linear] <c4>: <soc_t_3>[C] -2<x_1>[C] == 0;
+  [nonlinear] <c5>: <soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_1>*<soc_t_1> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 + [ -1 x * x ] >= +0
-Bounds
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[0,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-<x>*<x> >= 0;
+END

--- a/tests/snapshots/scip/simple_15.txt
+++ b/tests/snapshots/scip/simple_15.txt
@@ -7,26 +7,28 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_1 <= +0
- c2: +1 soc_t_1 -1 x_0 = +1
- c3: +1 soc_t_2 -1 x_0 = -1
- c4: +1 soc_t_3 -2 x_1 = -2
- c5: + [ +1 soc_t_2 * soc_t_2 +1 soc_t_3 * soc_t_3 -1 soc_t_1 * soc_t_1 ] <= +0
-Bounds
- x_0 free
- x_1 free
- soc_t_2 free
- soc_t_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_1>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_1>[C] <= 0;
+  [linear] <c2>: <soc_t_1>[C] -<x_0>[C] == 1;
+  [linear] <c3>: <soc_t_2>[C] -<x_0>[C] == -1;
+  [linear] <c4>: <soc_t_3>[C] -2<x_1>[C] == -2;
+  [nonlinear] <c5>: <soc_t_2>*<soc_t_2>+<soc_t_3>*<soc_t_3>-<soc_t_1>*<soc_t_1> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x2
-Subject to
- c1: +1 x2 +2 x + [ -1 x * x ] >= +1
-Bounds
- x2 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[0,+inf]
+  [continuous] <x2>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x2>-<x>*<x>+2*<x> >= 1;
+END

--- a/tests/snapshots/scip/simple_16.txt
+++ b/tests/snapshots/scip/simple_16.txt
@@ -8,35 +8,39 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_2 <= +0
- c2: -1 x_3 <= +0
- c3: +1 soc_t_2 -1 x_0 = +1
- c4: +1 soc_t_3 -1 x_0 = -1
- c5: +1 soc_t_4 -2 x_2 = +0
- c6: + [ +1 soc_t_3 * soc_t_3 +1 soc_t_4 * soc_t_4 -1 soc_t_2 * soc_t_2 ] <= +0
- c7: +1 soc_t_5 -1 x_1 = +1
- c8: +1 soc_t_6 -1 x_1 = -1
- c9: +1 soc_t_7 -2 x_3 = +0
- c10: + [ +1 soc_t_6 * soc_t_6 +1 soc_t_7 * soc_t_7 -1 soc_t_5 * soc_t_5 ] <= +0
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- soc_t_3 free
- soc_t_4 free
- soc_t_6 free
- soc_t_7 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_2>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_3>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_4>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_5>: obj=0, original bounds=[0,+inf]
+  [continuous] <soc_t_6>: obj=0, original bounds=[-inf,+inf]
+  [continuous] <soc_t_7>: obj=0, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_2>[C] <= 0;
+  [linear] <c2>:  -<x_3>[C] <= 0;
+  [linear] <c3>: <soc_t_2>[C] -<x_0>[C] == 1;
+  [linear] <c4>: <soc_t_3>[C] -<x_0>[C] == -1;
+  [linear] <c5>: <soc_t_4>[C] -2<x_2>[C] == 0;
+  [nonlinear] <c6>: <soc_t_3>*<soc_t_3>+<soc_t_4>*<soc_t_4>-<soc_t_2>*<soc_t_2> <= 0;
+  [linear] <c7>: <soc_t_5>[C] -<x_1>[C] == 1;
+  [linear] <c8>: <soc_t_6>[C] -<x_1>[C] == -1;
+  [linear] <c9>: <soc_t_7>[C] -2<x_3>[C] == 0;
+  [nonlinear] <c10>: <soc_t_6>*<soc_t_6>+<soc_t_7>*<soc_t_7>-<soc_t_5>*<soc_t_5> <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x3
-Subject to
- c1: +1 x3 + [ -1 x * x -1 y * y ] >= +0
-Bounds
- x3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=0, original bounds=[0,+inf]
+  [continuous] <y>: obj=0, original bounds=[0,+inf]
+  [continuous] <x3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [nonlinear] <c1>: <x3>-<x>*<x>-<y>*<y> >= 0;
+END

--- a/tests/snapshots/scip/sum_axis_00.txt
+++ b/tests/snapshots/scip/sum_axis_00.txt
@@ -9,25 +9,29 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +2 x_1 +3 x_2 +4 x_3
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
- c5: -1 x_0 -1 x_1 -1 x_2 -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=3, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=4, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_1>[C] -<x_2>[C] -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
-Subject to
- 7: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1 >= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_0_1>: obj=3, original bounds=[0,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[0,+inf]
+  [continuous] <x_1_1>: obj=4, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <7>: <x_0_0>[C] +<x_0_1>[C] +<x_1_0>[C] +<x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/sum_axis_01.txt
+++ b/tests/snapshots/scip/sum_axis_01.txt
@@ -9,27 +9,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +2 x_1 +3 x_2 +4 x_3
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
- c5: -1 x_0 -1 x_1 <= -1
- c6: -1 x_2 -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=3, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=4, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_1>[C] <= -1;
+  [linear] <c6>:  -<x_2>[C] -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
-Subject to
- 13_0: +1 x_0_0 +1 x_1_0 >= +1
- 13_1: +1 x_0_1 +1 x_1_1 >= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_0_1>: obj=3, original bounds=[0,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[0,+inf]
+  [continuous] <x_1_1>: obj=4, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <13_0>: <x_0_0>[C] +<x_1_0>[C] >= 1;
+  [linear] <13_1>: <x_0_1>[C] +<x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/sum_axis_02.txt
+++ b/tests/snapshots/scip/sum_axis_02.txt
@@ -9,27 +9,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +2 x_1 +3 x_2 +4 x_3
-Subject to
- c1: -1 x_0 <= +0
- c2: -1 x_1 <= +0
- c3: -1 x_2 <= +0
- c4: -1 x_3 <= +0
- c5: -1 x_0 -1 x_2 <= -1
- c6: -1 x_1 -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=3, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=4, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+  [linear] <c2>:  -<x_1>[C] <= 0;
+  [linear] <c3>:  -<x_2>[C] <= 0;
+  [linear] <c4>:  -<x_3>[C] <= 0;
+  [linear] <c5>:  -<x_0>[C] -<x_2>[C] <= -1;
+  [linear] <c6>:  -<x_1>[C] -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
-Subject to
- 19_0: +1 x_0_0 +1 x_0_1 >= +1
- 19_1: +1 x_1_0 +1 x_1_1 >= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_0_1>: obj=3, original bounds=[0,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[0,+inf]
+  [continuous] <x_1_1>: obj=4, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <19_0>: <x_0_0>[C] +<x_0_1>[C] >= 1;
+  [linear] <19_1>: <x_1_0>[C] +<x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/sum_axis_03.txt
+++ b/tests/snapshots/scip/sum_axis_03.txt
@@ -12,10 +12,14 @@ AFTER COMPILATION
 cannot reshape array of size 1 into shape (2,)
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +3 x_0_1 +2 x_1_0 +4 x_1_1
-Subject to
- 25_0: +1 x_0_0 +1 x_0_1 >= +1
- 25_1: +1 x_1_0 +1 x_1_1 >= +1
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[0,+inf]
+  [continuous] <x_0_1>: obj=3, original bounds=[0,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[0,+inf]
+  [continuous] <x_1_1>: obj=4, original bounds=[0,+inf]
+CONSTRAINTS
+  [linear] <25_0>: <x_0_0>[C] +<x_0_1>[C] >= 1;
+  [linear] <25_1>: <x_1_0>[C] +<x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/sum_scalar_00.txt
+++ b/tests/snapshots/scip/sum_scalar_00.txt
@@ -7,17 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/sum_scalar_01.txt
+++ b/tests/snapshots/scip/sum_scalar_01.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/sum_scalar_02.txt
+++ b/tests/snapshots/scip/sum_scalar_02.txt
@@ -7,17 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/sum_scalar_03.txt
+++ b/tests/snapshots/scip/sum_scalar_03.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/sum_scalar_04.txt
+++ b/tests/snapshots/scip/sum_scalar_04.txt
@@ -7,17 +7,17 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/sum_scalar_05.txt
+++ b/tests/snapshots/scip/sum_scalar_05.txt
@@ -7,17 +7,18 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= +0
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= 0;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +1
-Subject to
-Bounds
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[0,+inf]
+END

--- a/tests/snapshots/scip/vstack_00.txt
+++ b/tests/snapshots/scip/vstack_00.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0
-Subject to
- 7_0: +1 x_0 >= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <7_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_01.txt
+++ b/tests/snapshots/scip/vstack_01.txt
@@ -10,23 +10,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 y_0 +1
-Subject to
- 13_0: +1 x_0 >= +1
- 17_0: +1 y_0 >= +1
-Bounds
- x_0 free
- y_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <13_0>: <x_0>[C] >= 1;
+  [linear] <17_0>: <y_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_02.txt
+++ b/tests/snapshots/scip/vstack_02.txt
@@ -8,19 +8,19 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0
-Subject to
- c1: -1 x_0 <= -1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0
-Subject to
- 24_0: +1 x_0 >= +1
-Bounds
- x_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <24_0>: <x_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_03.txt
+++ b/tests/snapshots/scip/vstack_03.txt
@@ -10,23 +10,24 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +3 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0 +3 y_0 +1
-Subject to
- 32_0: +1 x_0 >= +1
- 36_0: +1 y_0 >= +1
-Bounds
- x_0 free
- y_0 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +1
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <y_0>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <32_0>: <x_0>[C] >= 1;
+  [linear] <36_0>: <y_0>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_04.txt
+++ b/tests/snapshots/scip/vstack_04.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0 +1 x_1
-Subject to
- 7_0: +1 x_0 >= +1
- 7_1: +1 x_1 >= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <7_0>: <x_0>[C] >= 1;
+  [linear] <7_1>: <x_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_05.txt
+++ b/tests/snapshots/scip/vstack_05.txt
@@ -8,23 +8,23 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +2 x_1
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0 +2 x_1
-Subject to
- 16_0: +1 x_0 >= +1
- 16_1: +1 x_1 >= +1
-Bounds
- x_0 free
- x_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <16_0>: <x_0>[C] >= 1;
+  [linear] <16_1>: <x_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_06.txt
+++ b/tests/snapshots/scip/vstack_06.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1
-Subject to
- 8_0_0: +1 x_0_0 >= +1
- 8_0_1: +1 x_0_1 >= +1
- 8_1_0: +1 x_1_0 >= +1
- 8_1_1: +1 x_1_1 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <8_0_0>: <x_0_0>[C] >= 1;
+  [linear] <8_0_1>: <x_0_1>[C] >= 1;
+  [linear] <8_1_0>: <x_1_0>[C] >= 1;
+  [linear] <8_1_1>: <x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_07.txt
+++ b/tests/snapshots/scip/vstack_07.txt
@@ -11,39 +11,40 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +1 x_0 +1 x_1 +1 x_2 +1 x_3 +1 x_4 +1 x_5
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
- c5: -1 x_4 <= -1
- c6: -1 x_5 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+  [linear] <c5>:  -<x_4>[C] <= -1;
+  [linear] <c6>:  -<x_5>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +1 x_0_0 +1 x_0_1 +1 x_1_0 +1 x_1_1 +1 y_0_0 +1 y_0_1 +6
-Subject to
- 15_0_0: +1 x_0_0 >= +1
- 15_0_1: +1 x_0_1 >= +1
- 15_1_0: +1 x_1_0 >= +1
- 15_1_1: +1 x_1_1 >= +1
- 20_0_0: +1 y_0_0 >= +1
- 20_0_1: +1 y_0_1 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
- y_0_0 free
- y_0_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +6
+VARIABLES
+  [continuous] <x_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0_0>: obj=1, original bounds=[-inf,+inf]
+  [continuous] <y_0_1>: obj=1, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <15_0_0>: <x_0_0>[C] >= 1;
+  [linear] <15_0_1>: <x_0_1>[C] >= 1;
+  [linear] <15_1_0>: <x_1_0>[C] >= 1;
+  [linear] <15_1_1>: <x_1_1>[C] >= 1;
+  [linear] <20_0_0>: <y_0_0>[C] >= 1;
+  [linear] <20_0_1>: <y_0_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_08.txt
+++ b/tests/snapshots/scip/vstack_08.txt
@@ -8,31 +8,31 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1
-Subject to
- 29_0_0: +1 x_0_0 >= +1
- 29_0_1: +1 x_0_1 >= +1
- 29_1_0: +1 x_1_0 >= +1
- 29_1_1: +1 x_1_1 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=2, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <29_0_0>: <x_0_0>[C] >= 1;
+  [linear] <29_0_1>: <x_0_1>[C] >= 1;
+  [linear] <29_1_0>: <x_1_0>[C] >= 1;
+  [linear] <29_1_1>: <x_1_1>[C] >= 1;
+END

--- a/tests/snapshots/scip/vstack_09.txt
+++ b/tests/snapshots/scip/vstack_09.txt
@@ -11,39 +11,40 @@ Bounds
 End
 ----------------------------------------
 AFTER COMPILATION
-Minimize
- Obj: +2 x_0 +2 x_1 +2 x_2 +2 x_3 +3 x_4 +3 x_5
-Subject to
- c1: -1 x_0 <= -1
- c2: -1 x_1 <= -1
- c3: -1 x_2 <= -1
- c4: -1 x_3 <= -1
- c5: -1 x_4 <= -1
- c6: -1 x_5 <= -1
-Bounds
- x_0 free
- x_1 free
- x_2 free
- x_3 free
- x_4 free
- x_5 free
-End
+OBJECTIVE
+  Sense            : minimize
+VARIABLES
+  [continuous] <x_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_2>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_3>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_4>: obj=3, original bounds=[-inf,+inf]
+  [continuous] <x_5>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <c1>:  -<x_0>[C] <= -1;
+  [linear] <c2>:  -<x_1>[C] <= -1;
+  [linear] <c3>:  -<x_2>[C] <= -1;
+  [linear] <c4>:  -<x_3>[C] <= -1;
+  [linear] <c5>:  -<x_4>[C] <= -1;
+  [linear] <c6>:  -<x_5>[C] <= -1;
+END
 ----------------------------------------
 SCIP
-Minimize
- Obj: +2 x_0_0 +2 x_0_1 +2 x_1_0 +2 x_1_1 +3 y_0_0 +3 y_0_1 +6
-Subject to
- 40_0_0: +1 x_0_0 >= +1
- 40_0_1: +1 x_0_1 >= +1
- 40_1_0: +1 x_1_0 >= +1
- 40_1_1: +1 x_1_1 >= +1
- 45_0_0: +1 y_0_0 >= +1
- 45_0_1: +1 y_0_1 >= +1
-Bounds
- x_0_0 free
- x_0_1 free
- x_1_0 free
- x_1_1 free
- y_0_0 free
- y_0_1 free
-End
+OBJECTIVE
+  Sense            : minimize
+  Offset           : +6
+VARIABLES
+  [continuous] <x_0_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_0_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_0>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <x_1_1>: obj=2, original bounds=[-inf,+inf]
+  [continuous] <y_0_0>: obj=3, original bounds=[-inf,+inf]
+  [continuous] <y_0_1>: obj=3, original bounds=[-inf,+inf]
+CONSTRAINTS
+  [linear] <40_0_0>: <x_0_0>[C] >= 1;
+  [linear] <40_0_1>: <x_0_1>[C] >= 1;
+  [linear] <40_1_0>: <x_1_0>[C] >= 1;
+  [linear] <40_1_1>: <x_1_1>[C] >= 1;
+  [linear] <45_0_0>: <y_0_0>[C] >= 1;
+  [linear] <45_0_1>: <y_0_1>[C] >= 1;
+END

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -254,7 +254,7 @@ def lp_from_gurobi(model: gp.Model, tmp_path: Path) -> list[str]:
 
 
 def lp_from_scip(model: scip.Model, tmp_path: Path) -> list[str]:
-    out_path = tmp_path / "scip.lp"
+    out_path = tmp_path / "scip.cip"
     model.writeProblem(str(out_path), verbose=False)
     return out_path.read_text().splitlines()[4:]
 


### PR DESCRIPTION
Since SCIP 10 cannot write non-linear terms in LP format anymore, see https://github.com/scipopt/PySCIPOpt/issues/1138