### PR TITLE
Disable new ruff rule RUF067

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: prettier
         args: [--prose-wrap=always]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.13
     hooks:
       - id: ruff-check
         args: [--fix, "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ ignore = [
   "TD",      # TODOs are fine
   "PLC0415", # `import` not at top of file is on purpose
   "PLR2004", # 'magic' constants are not that annoying
+  "RUF067",  # try-except in __init__.py file
   "S101",    # asserts used for type narrowing
 ]
 exclude = [


### PR DESCRIPTION
There is a `try-except` statement in `__init__.py` to handle both `cvxpy` and `cvxpy-base`, but I also don't really agree with the rule.